### PR TITLE
feat: change the cmd layout for go install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,36 @@ go.work.sum
 
 # env file
 .env
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### macOS Patch ###
+# iCloud generated files
+*.icloud

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package modctl
+package cmd
 
 import (
 	"bufio"

--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -14,62 +14,51 @@
  * limitations under the License.
  */
 
-package modctl
+package cmd
 
 import (
 	"context"
 	"fmt"
-	"os"
-	"text/tabwriter"
 
 	"github.com/CloudNativeAI/modctl/pkg/backend"
 
-	humanize "github.com/dustin/go-humanize"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
-// listCmd represents the modctl command for list.
-var listCmd = &cobra.Command{
-	Use:                "ls",
-	Short:              "A command line tool for modctl list",
-	Args:               cobra.NoArgs,
+// logoutCmd represents the modctl command for logout.
+var logoutCmd = &cobra.Command{
+	Use:                "logout [flags]",
+	Short:              "A command line tool for modctl logout",
+	Args:               cobra.ExactArgs(1),
 	DisableAutoGenTag:  true,
 	SilenceUsage:       true,
 	FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runList(context.Background())
+		return runLogout(context.Background(), args[0])
 	},
 }
 
-// init initializes list command.
+// init initializes logout command.
 func init() {
-	flags := listCmd.Flags()
+	flags := logoutCmd.Flags()
 
 	if err := viper.BindPFlags(flags); err != nil {
-		panic(fmt.Errorf("bind cache list flags to viper: %w", err))
+		panic(fmt.Errorf("bind cache logout flags to viper: %w", err))
 	}
 }
 
-// runList runs the list modctl.
-func runList(ctx context.Context) error {
+// runLogout runs the logout modctl.
+func runLogout(ctx context.Context, registry string) error {
 	b, err := backend.New()
 	if err != nil {
 		return err
 	}
 
-	artifacts, err := b.List(ctx)
-	if err != nil {
+	if err := b.Logout(ctx, registry); err != nil {
 		return err
 	}
 
-	tw := tabwriter.NewWriter(os.Stderr, 0, 0, 4, ' ', 0)
-	defer tw.Flush()
-	fmt.Fprintln(tw, "REPOSITORY\tTAG\tDIGEST\tCREATED\tSIZE")
-
-	for _, artifact := range artifacts {
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", artifact.Repository, artifact.Tag, artifact.Digest, humanize.Time(artifact.CreatedAt), humanize.IBytes(uint64(artifact.Size)))
-	}
-
+	fmt.Println("Logout Succeeded.")
 	return nil
 }

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package modctl
+package cmd
 
 import (
 	"context"
@@ -27,47 +27,47 @@ import (
 	"github.com/spf13/viper"
 )
 
-var buildConfig = config.NewBuild()
+var pushConfig = config.NewPull()
 
-// buildCmd represents the modctl command for build.
-var buildCmd = &cobra.Command{
-	Use:                "build [flags] <path>",
-	Short:              "A command line tool for modctl build",
+// pushCmd represents the modctl command for push.
+var pushCmd = &cobra.Command{
+	Use:                "push [flags] <target>",
+	Short:              "A command line tool for modctl push",
 	Args:               cobra.ExactArgs(1),
 	DisableAutoGenTag:  true,
 	SilenceUsage:       true,
 	FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := buildConfig.Validate(); err != nil {
-			return err
-		}
-
-		return runBuild(context.Background(), args[0])
+		return runPush(context.Background(), args[0])
 	},
 }
 
-// init initializes build command.
+// init initializes push command.
 func init() {
-	flags := buildCmd.Flags()
-	flags.StringVarP(&buildConfig.Target, "target", "t", "", "target model artifact name")
-	flags.StringVarP(&buildConfig.Modelfile, "modelfile", "f", "", "model file path")
+	flags := pushCmd.Flags()
+	flags.BoolVarP(&pushConfig.PlainHTTP, "plain-http", "p", false, "use plain HTTP instead of HTTPS")
 
 	if err := viper.BindPFlags(flags); err != nil {
-		panic(fmt.Errorf("bind cache list flags to viper: %w", err))
+		panic(fmt.Errorf("bind cache push flags to viper: %w", err))
 	}
 }
 
-// runBuild runs the build modctl.
-func runBuild(ctx context.Context, workDir string) error {
+// runPush runs the push modctl.
+func runPush(ctx context.Context, target string) error {
 	b, err := backend.New()
 	if err != nil {
 		return err
 	}
 
-	if err := b.Build(ctx, buildConfig.Modelfile, workDir, buildConfig.Target); err != nil {
+	opts := []backend.Option{}
+	if pushConfig.PlainHTTP {
+		opts = append(opts, backend.WithPlainHTTP())
+	}
+
+	if err := b.Push(ctx, target, opts...); err != nil {
 		return err
 	}
 
-	fmt.Printf("Successfully built model artifact: %s\n", buildConfig.Target)
+	fmt.Printf("Successfully pushed model artifact: %s\n", target)
 	return nil
 }

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package modctl
+package cmd
 
 import (
 	"context"
@@ -26,39 +26,44 @@ import (
 	"github.com/spf13/viper"
 )
 
-// logoutCmd represents the modctl command for logout.
-var logoutCmd = &cobra.Command{
-	Use:                "logout [flags]",
-	Short:              "A command line tool for modctl logout",
+// rmCmd represents the modctl command for rm.
+var rmCmd = &cobra.Command{
+	Use:                "rm [flags] <target>",
+	Short:              "A command line tool for modctl rm",
 	Args:               cobra.ExactArgs(1),
 	DisableAutoGenTag:  true,
 	SilenceUsage:       true,
 	FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runLogout(context.Background(), args[0])
+		return runRm(context.Background(), args[0])
 	},
 }
 
-// init initializes logout command.
+// init initializes rm command.
 func init() {
-	flags := logoutCmd.Flags()
+	flags := rmCmd.Flags()
 
 	if err := viper.BindPFlags(flags); err != nil {
-		panic(fmt.Errorf("bind cache logout flags to viper: %w", err))
+		panic(fmt.Errorf("bind cache rm flags to viper: %w", err))
 	}
 }
 
-// runLogout runs the logout modctl.
-func runLogout(ctx context.Context, registry string) error {
+// runRm runs the rm modctl.
+func runRm(ctx context.Context, target string) error {
 	b, err := backend.New()
 	if err != nil {
 		return err
 	}
 
-	if err := b.Logout(ctx, registry); err != nil {
+	if target == "" {
+		return fmt.Errorf("target is required")
+	}
+
+	digest, err := b.Remove(ctx, target)
+	if err != nil {
 		return err
 	}
 
-	fmt.Println("Logout Succeeded.")
+	fmt.Printf("Deleted: %s\n", digest)
 	return nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package modctl
+package cmd
 
 import (
 	"os"

--- a/main.go
+++ b/main.go
@@ -16,8 +16,8 @@
 
 package main
 
-import "github.com/CloudNativeAI/modctl/cmd/modctl"
+import "github.com/CloudNativeAI/modctl/cmd"
 
 func main() {
-	modctl.Execute()
+	cmd.Execute()
 }


### PR DESCRIPTION
This pull request includes a series of renames and package adjustments to simplify the module structure by moving files from the `modctl` package to the `cmd` package.

File renames and package adjustments:

* [`cmd/build.go`](diffhunk://#diff-5794c40aa4c9301aaf9c39eacf7d3c8511f2511cb24bdd95e0a08704ba583a5fL17-R17): Renamed from `cmd/modctl/build.go` and updated the package declaration from `modctl` to `cmd`.
* [`cmd/list.go`](diffhunk://#diff-2cb6b39b26188bd68fce779dd82957aa4b969400c8a1554746a19f388924d9e5L17-R17): Renamed from `cmd/modctl/list.go` and updated the package declaration from `modctl` to `cmd`.
* [`cmd/login.go`](diffhunk://#diff-4e497e80de2b0f5468ea1ef74dc7ed5e6eaa10c8808c8a463878a9a9ec79799dL17-R17): Renamed from `cmd/modctl/login.go` and updated the package declaration from `modctl` to `cmd`.
* [`cmd/logout.go`](diffhunk://#diff-bb1897c585979dfcef1410c22c884bce52e511cf478d7de518cdb912ab28b003L17-R17): Renamed from `cmd/modctl/logout.go` and updated the package declaration from `modctl` to `cmd`.
* [`cmd/prune.go`](diffhunk://#diff-1c4061944cc223530f04ff22f54f259e7a1517bfe15dbf63728ec7074f1d54a6L17-R17): Renamed from `cmd/modctl/prune.go` and updated the package declaration from `modctl` to `cmd`.
* [`cmd/pull.go`](diffhunk://#diff-d083b2621fc1453b30bfe075a3f58f2844ed7b124a62e0a86c284290d00511e4L17-R17): Renamed from `cmd/modctl/pull.go` and updated the package declaration from `modctl` to `cmd`.
* [`cmd/push.go`](diffhunk://#diff-e8011aeef8362327cdc0e4492778f39d0eb835e4cafe821111e3446637cc862eL17-R17): Renamed from `cmd/modctl/push.go` and updated the package declaration from `modctl` to `cmd`.
* [`cmd/rm.go`](diffhunk://#diff-8948c5a258a947160c86c50242b8319d5be9a5ee3895e14a743ee09999661544L17-R17): Renamed from `cmd/modctl/rm.go` and updated the package declaration from `modctl` to `cmd`.
* [`cmd/root.go`](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL17-R17): Renamed from `cmd/modctl/root.go` and updated the package declaration from `modctl` to `cmd`.
* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L19-R22): Renamed from `cmd/main.go`, updated the import path from `github.com/CloudNativeAI/modctl/cmd/modctl` to `github.com/CloudNativeAI/modctl/cmd`, and adjusted the `Execute` function call accordingly.