### PR TITLE
feat: add the inspect command

### DIFF
--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -1,0 +1,75 @@
+/*
+ *     Copyright 2024 The CNAI Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/CloudNativeAI/modctl/pkg/backend"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// inspectCmd represents the modctl command for inspect.
+var inspectCmd = &cobra.Command{
+	Use:                "inspect [flags] <target>",
+	Short:              "A command line tool for modctl inspect",
+	Args:               cobra.ExactArgs(1),
+	DisableAutoGenTag:  true,
+	SilenceUsage:       true,
+	FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runInspect(context.Background(), args[0])
+	},
+}
+
+// init initializes inspect command.
+func init() {
+	flags := rmCmd.Flags()
+
+	if err := viper.BindPFlags(flags); err != nil {
+		panic(fmt.Errorf("bind cache inspect flags to viper: %w", err))
+	}
+}
+
+// runInspect runs the inspect modctl.
+func runInspect(ctx context.Context, target string) error {
+	b, err := backend.New()
+	if err != nil {
+		return err
+	}
+
+	if target == "" {
+		return fmt.Errorf("target is required")
+	}
+
+	inspected, err := b.Inspect(ctx, target)
+	if err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(inspected, "", "	")
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(string(data))
+	return nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -65,4 +65,5 @@ func init() {
 	rootCmd.AddCommand(pushCmd)
 	rootCmd.AddCommand(rmCmd)
 	rootCmd.AddCommand(pruneCmd)
+	rootCmd.AddCommand(inspectCmd)
 }

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -47,6 +47,9 @@ type Backend interface {
 
 	// Prune prunes the unused blobs and clean up the storage.
 	Prune(ctx context.Context) ([]string, error)
+
+	// Inspect inspects the model artifact.
+	Inspect(ctx context.Context, target string) (*InspectedModelArtifact, error)
 }
 
 // backend is the implementation of Backend.

--- a/pkg/backend/inspect.go
+++ b/pkg/backend/inspect.go
@@ -1,0 +1,104 @@
+/*
+ *     Copyright 2024 The CNAI Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package backend
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	modelspec "github.com/CloudNativeAI/modctl/pkg/spec"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// InspectedModelArtifact is the data structure for model artifact that has been inspected.
+type InspectedModelArtifact struct {
+	// ID is the image id of the model artifact.
+	ID string `json:"Id"`
+	// Digest is the digest of the model artifact.
+	Digest string `json:"Digest"`
+	// Architecture is the architecture of the model.
+	Architecture string `json:"Architecture"`
+	// Created is the creation time of the model artifact.
+	Created string `json:"Created"`
+	// Family is the family of the model.
+	Family string `json:"Family"`
+	// Format is the format of the model.
+	Format string `json:"Format"`
+	// Name is the name of the model.
+	Name string `json:"Name"`
+	// ParamSize is the param size of the model.
+	ParamSize string `json:"ParamSize"`
+	// Precision is the precision of the model.
+	Precision string `json:"Precision"`
+	// Quantization is the quantization of the model.
+	Quantization string `json:"Quantization"`
+	// Layers is the layers of the model artifact.
+	Layers []InspectedModelArtifactLayer `json:"Layers"`
+}
+
+// InspectedModelArtifactLayer is the data structure for model artifact layer that has been inspected.
+type InspectedModelArtifactLayer struct {
+	// Digest is the digest of the model artifact layer.
+	Digest string `json:"Digest"`
+	// Size is the size of the model artifact layer.
+	Size int64 `json:"Size"`
+	// Filepath is the filepath of the model artifact layer.
+	Filepath string `json:"Filepath"`
+}
+
+// Inspect inspects the target from the storage.
+func (b *backend) Inspect(ctx context.Context, target string) (*InspectedModelArtifact, error) {
+	ref, err := ParseReference(target)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse target: %w", err)
+	}
+
+	repo, tag := ref.Repository(), ref.Tag()
+	manifestRaw, digest, err := b.store.PullManifest(ctx, repo, tag)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get manifest: %w", err)
+	}
+
+	var manifest ocispec.Manifest
+	if err := json.Unmarshal(manifestRaw, &manifest); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal manifest: %w", err)
+	}
+
+	inspectedModelArtifact := &InspectedModelArtifact{
+		ID:           manifest.Config.Digest.String(),
+		Digest:       digest,
+		Architecture: manifest.Annotations[modelspec.AnnotationArchitecture],
+		Created:      manifest.Annotations[modelspec.AnnotationCreated],
+		Family:       manifest.Annotations[modelspec.AnnotationFamily],
+		Format:       manifest.Annotations[modelspec.AnnotationFormat],
+		Name:         manifest.Annotations[modelspec.AnnotationName],
+		ParamSize:    manifest.Annotations[modelspec.AnnotationParamSize],
+		Precision:    manifest.Annotations[modelspec.AnnotationPrecision],
+		Quantization: manifest.Annotations[modelspec.AnnotationQuantization],
+	}
+
+	for _, layer := range manifest.Layers {
+		inspectedModelArtifact.Layers = append(inspectedModelArtifact.Layers, InspectedModelArtifactLayer{
+			Digest:   layer.Digest.String(),
+			Size:     layer.Size,
+			Filepath: layer.Annotations[modelspec.AnnotationFilepath],
+		})
+	}
+
+	return inspectedModelArtifact, nil
+}

--- a/pkg/backend/inspect_test.go
+++ b/pkg/backend/inspect_test.go
@@ -1,0 +1,153 @@
+/*
+ *     Copyright 2024 The CNAI Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package backend
+
+import (
+	"context"
+	"testing"
+
+	"github.com/CloudNativeAI/modctl/test/mocks/storage"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInspect(t *testing.T) {
+	mockStore := &storage.Storage{}
+	b := &backend{store: mockStore}
+	ctx := context.Background()
+	target := "example.com/repo:tag"
+	manifest := `{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "artifactType": "application/vnd.cnai.model.manifest.v1+json",
+  "config": {
+    "mediaType": "application/vnd.oci.image.config.v1+json",
+    "digest": "sha256:144ac462bafbbc7cc6c9e6b325049a0aca1b6ffa2f6cfb0a80ec64bc690bec04",
+    "size": 46
+  },
+  "layers": [
+    {
+      "mediaType": "application/vnd.oci.image.layer.v1.tar",
+      "digest": "sha256:5a96686deb327903f4310e9181ef2ee0bc7261e5181bd23ccdce6c575b6120a2",
+      "size": 13312,
+      "annotations": {
+        "org.cnai.model.filepath": "LICENSE",
+        "org.cnai.model.license": "true"
+      },
+      "artifactType": "application/vnd.cnai.model.layer.v1.tar"
+    },
+    {
+      "mediaType": "application/vnd.oci.image.layer.v1.tar",
+      "digest": "sha256:44a6e989cc7084ef35aedf1dd7090204ccc928829c51ce79d7d59c346a228333",
+      "size": 5632,
+      "annotations": {
+        "org.cnai.model.filepath": "README.md",
+        "org.cnai.model.readme": "true"
+      },
+      "artifactType": "application/vnd.cnai.model.layer.v1.tar"
+    },
+    {
+      "mediaType": "application/vnd.oci.image.layer.v1.tar",
+      "digest": "sha256:a4e7c313c8addcc5f8ac3d87d48a9af7eb89bf8819c869c9fa0cad1026397b0c",
+      "size": 2560,
+      "annotations": {
+        "org.cnai.model.config": "true",
+        "org.cnai.model.filepath": "config.json"
+      },
+      "artifactType": "application/vnd.cnai.model.layer.v1.tar"
+    },
+    {
+      "mediaType": "application/vnd.oci.image.layer.v1.tar",
+      "digest": "sha256:567f11b7338855adbaf58c8e195455860400ef148fc7f02ebc446efdb8b7c515",
+      "size": 1536,
+      "annotations": {
+        "org.cnai.model.config": "true",
+        "org.cnai.model.filepath": "foo/bar.json"
+      },
+      "artifactType": "application/vnd.cnai.model.layer.v1.tar"
+    },
+    {
+      "mediaType": "application/vnd.oci.image.layer.v1.tar",
+      "digest": "sha256:628ce381719b65598622e3f71844192f84e135d937c7b5a8116582edbe3b1f5d",
+      "size": 2048,
+      "annotations": {
+        "org.cnai.model.config": "true",
+        "org.cnai.model.filepath": "generation_config.json"
+      },
+      "artifactType": "application/vnd.cnai.model.layer.v1.tar"
+    },
+    {
+      "mediaType": "application/vnd.oci.image.layer.v1.tar",
+      "digest": "sha256:0480097912f4dd530382c69f00d41409bc51f62ea146a04d70c0254791f4ac32",
+      "size": 7033344,
+      "annotations": {
+        "org.cnai.model.config": "true",
+        "org.cnai.model.filepath": "tokenizer.json"
+      },
+      "artifactType": "application/vnd.cnai.model.layer.v1.tar"
+    },
+    {
+      "mediaType": "application/vnd.oci.image.layer.v1.tar",
+      "digest": "sha256:ebea935e6c2de57780addfc0262c30c2f83afb1457a124fd9b22370e6cb5bc34",
+      "size": 9216,
+      "annotations": {
+        "org.cnai.model.config": "true",
+        "org.cnai.model.filepath": "tokenizer_config.json"
+      },
+      "artifactType": "application/vnd.cnai.model.layer.v1.tar"
+    },
+    {
+      "mediaType": "application/vnd.oci.image.layer.v1.tar",
+      "digest": "sha256:3a2844a891e19d1d183ac12918a497116309ba9abe0523cdcf1874cf8aebe8e0",
+      "size": 2778624,
+      "annotations": {
+        "org.cnai.model.config": "true",
+        "org.cnai.model.filepath": "vocab.json"
+      },
+      "artifactType": "application/vnd.cnai.model.layer.v1.tar"
+    }
+  ],
+  "annotations": {
+    "org.cnai.model.architecture": "transformer",
+    "org.cnai.model.created": "2024-11-11T21:16:41+08:00",
+    "org.cnai.model.family": "qwen2",
+    "org.cnai.model.format": "tensorflow",
+    "org.cnai.model.name": "Qwen2.5-0.5B",
+    "org.cnai.model.param.size": "0.49B",
+    "org.cnai.model.precision": "int8",
+    "org.cnai.model.quantization": "gptq"
+  }
+}`
+
+	mockStore.On("PullManifest", ctx, "example.com/repo", "tag").Return([]byte(manifest), "sha256:2bc8836f5910ec63a01109e20db67c2ad7706cb19bef5a303bc86fa5572ec9a2", nil)
+
+	inspected, err := b.Inspect(ctx, target)
+	assert.NoError(t, err)
+	assert.Equal(t, "sha256:144ac462bafbbc7cc6c9e6b325049a0aca1b6ffa2f6cfb0a80ec64bc690bec04", inspected.ID)
+	assert.Equal(t, "sha256:2bc8836f5910ec63a01109e20db67c2ad7706cb19bef5a303bc86fa5572ec9a2", inspected.Digest)
+	assert.Equal(t, "transformer", inspected.Architecture)
+	assert.Equal(t, "2024-11-11T21:16:41+08:00", inspected.Created)
+	assert.Equal(t, "qwen2", inspected.Family)
+	assert.Equal(t, "tensorflow", inspected.Format)
+	assert.Equal(t, "Qwen2.5-0.5B", inspected.Name)
+	assert.Equal(t, "0.49B", inspected.ParamSize)
+	assert.Equal(t, "int8", inspected.Precision)
+	assert.Equal(t, "gptq", inspected.Quantization)
+	assert.Len(t, inspected.Layers, 8)
+	assert.Equal(t, "sha256:5a96686deb327903f4310e9181ef2ee0bc7261e5181bd23ccdce6c575b6120a2", inspected.Layers[0].Digest)
+	assert.Equal(t, "LICENSE", inspected.Layers[0].Filepath)
+	assert.Equal(t, int64(13312), inspected.Layers[0].Size)
+}


### PR DESCRIPTION
This pull request introduces a new `inspect` command to the `modctl` tool, which allows users to inspect model artifacts. The key changes include the addition of the `inspect` command, updates to the `Backend` interface, and the implementation of the `Inspect` method in the backend package.

### New `inspect` command:

* [`cmd/inspect.go`](diffhunk://#diff-e1112a72d67ea1111e0c19d52bd341c23830344021f7f8534ffa74df2ad51d20R1-R75): Added the `inspect` command implementation, which includes the `runInspect` function to handle the inspection logic.
* [`cmd/root.go`](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR68): Registered the new `inspect` command with the root command.

### Backend interface updates:

* [`pkg/backend/backend.go`](diffhunk://#diff-c65bcfe9bb457434c3e69ba3f0576d7669935f350d24e2c2c58b05b4f9c510b2R50-R52): Added the `Inspect` method to the `Backend` interface to inspect model artifacts.

### Implementation of the `Inspect` method:

* [`pkg/backend/inspect.go`](diffhunk://#diff-a94e5da4533561dba9ccbb2ab8b32d5c7952c5b3e6c2bfbd2a0a0cb901263388R1-R104): Implemented the `Inspect` method to inspect the target model artifact and return detailed information about it.

### Testing:

* [`pkg/backend/inspect_test.go`](diffhunk://#diff-bf4b648860bc807309b451a8c58ec58ab1d838f95822247ce74fbfdd44573013R1-R153): Added unit tests for the `Inspect` method to ensure it works correctly.