### PR TITLE
fix: add plain-http option for login cmd

### DIFF
--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -25,7 +25,7 @@ import (
 // Backend is the interface to represent the backend.
 type Backend interface {
 	// Login logs into a registry.
-	Login(ctx context.Context, registry, username, password string, insecure bool) error
+	Login(ctx context.Context, registry, username, password string, opts ...Option) error
 
 	// Logout logs out from a registry.
 	Logout(ctx context.Context, registry string) error

--- a/pkg/backend/login.go
+++ b/pkg/backend/login.go
@@ -18,13 +18,19 @@ package backend
 
 import (
 	"context"
+
 	"oras.land/oras-go/v2/registry/remote"
 	"oras.land/oras-go/v2/registry/remote/auth"
 	"oras.land/oras-go/v2/registry/remote/credentials"
 )
 
 // Login logs into a registry.
-func (b *backend) Login(ctx context.Context, registry, username, password string, insecure bool) error {
+func (b *backend) Login(ctx context.Context, registry, username, password string, opts ...Option) error {
+	// apply options.
+	options := &Options{}
+	for _, opt := range opts {
+		opt(options)
+	}
 	// read credentials from docker store.
 	store, err := credentials.NewStoreFromDocker(credentials.StoreOptions{AllowPlaintextPut: true})
 	if err != nil {
@@ -35,7 +41,10 @@ func (b *backend) Login(ctx context.Context, registry, username, password string
 	if err != nil {
 		return err
 	}
-	reg.PlainHTTP = insecure
+
+	if options.plainHTTP {
+		reg.PlainHTTP = true
+	}
 
 	cred := auth.Credential{
 		Username: username,

--- a/pkg/config/login.go
+++ b/pkg/config/login.go
@@ -22,7 +22,7 @@ type Login struct {
 	Username      string
 	Password      string
 	PasswordStdin bool
-	Insecure      bool
+	PlainHTTP     bool
 }
 
 func NewLogin() *Login {
@@ -30,7 +30,7 @@ func NewLogin() *Login {
 		Username:      "",
 		Password:      "",
 		PasswordStdin: true,
-		Insecure:      false,
+		PlainHTTP:     false,
 	}
 }
 


### PR DESCRIPTION
This pull request includes several changes to the `cmd/login.go` and `pkg/backend` files to replace the `Insecure` flag with a new `PlainHTTP` flag for allowing HTTP connections to the registry. Additionally, the backend login function has been modified to accept options.

Changes to `cmd/login.go`:

* Updated the login command description to reflect the new `PlainHTTP` flag.
* Replaced the `Insecure` flag with the `PlainHTTP` flag in the command initialization.
* Modified the `runLogin` function to handle the new `PlainHTTP` flag using backend options.

Changes to `pkg/backend`:

* Updated the `Login` method signature in the `Backend` interface to accept options instead of the `insecure` boolean.
* Modified the `Login` method implementation to apply the new options and handle the `PlainHTTP` flag accordingly. [[1]](diffhunk://#diff-e6269770be74d43476ad9be5e909f8ef9f189dabe8343e31f017a6fb8fbea19eR21-R33) [[2]](diffhunk://#diff-e6269770be74d43476ad9be5e909f8ef9f189dabe8343e31f017a6fb8fbea19eL38-R47)

Changes to `pkg/config/login.go`:

* Replaced the `Insecure` field with the `PlainHTTP` field in the `Login` struct and its constructor.