### PR TITLE
docs: change the registry address

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -59,7 +59,7 @@ MODEL \.safetensors$
 Then run the following command to build the model artifact:
 
 ```shell
-$ modctl build -t 127.0.0.1/library/test-models:v1 -f Modelfile .
+$ modctl build -t registry.com/models/llama3:v1.0.0 -f Modelfile .
 ```
 
 ### Pull & Push
@@ -73,13 +73,13 @@ $ modctl login -u username -p password example.registry.com
 Pull the model artifact from the registry:
 
 ```shell
-$ modctl pull 127.0.0.1/library/test-models:v1
+$ modctl pull registry.com/models/llama3:v1.0.0
 ```
 
 Push the model artifact to the registry:
 
 ```shell
-$ modctl push 127.0.0.1/library/test-models:v1
+$ modctl push registry.com/models/llama3:v1.0.0
 ```
 
 ### List
@@ -95,7 +95,7 @@ $ modctl ls
 Delete the model artifact in the local storage:
 
 ```shell
-$ modctl rm 127.0.0.1/library/test-models:v1
+$ modctl rm registry.com/models/llama3:v1.0.0
 ```
 
 Finally, you can use `purge` command to to remove all unnecessary blobs to free up the storage space:


### PR DESCRIPTION
This pull request includes updates to the `docs/getting-started.md` file to reflect changes in the model registry URLs. The most important changes include updating the commands for building, pulling, pushing, and deleting model artifacts.

Updates to model registry URLs:

* Updated the `modctl build` command to use the new registry URL `registry.com/models/llama3:v1.0.0` instead of the old URL `127.0.0.1/library/test-models:v1`.
* Updated the `modctl pull` command to use the new registry URL `registry.com/models/llama3:v1.0.0` instead of the old URL `127.0.0.1/library/test-models:v1`.
* Updated the `modctl push` command to use the new registry URL `registry.com/models/llama3:v1.0.0` instead of the old URL `127.0.0.1/library/test-models:v1`.
* Updated the `modctl rm` command to use the new registry URL `registry.com/models/llama3:v1.0.0` instead of the old URL `127.0.0.1/library/test-models:v1`.