### PR TITLE
feat: add insecure options for pull

### DIFF
--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -46,6 +46,7 @@ var pullCmd = &cobra.Command{
 func init() {
 	flags := pullCmd.Flags()
 	flags.BoolVar(&pullConfig.PlainHTTP, "plain-http", false, "use plain HTTP instead of HTTPS")
+	flags.BoolVar(&pullConfig.Insecure, "insecure", false, "use insecure connection for the pull operation and skip TLS verification")
 	flags.StringVar(&pullConfig.Proxy, "proxy", "", "use proxy for the pull operation")
 	flags.StringVar(&pullConfig.ExtractDir, "extract-dir", "", "specify the extract dir for extracting the model artifact")
 
@@ -65,7 +66,7 @@ func runPull(ctx context.Context, target string) error {
 		return fmt.Errorf("target is required")
 	}
 
-	opts := []backend.Option{}
+	opts := []backend.Option{backend.WithInsecure(pullConfig.Insecure)}
 	if pullConfig.PlainHTTP {
 		opts = append(opts, backend.WithPlainHTTP())
 	}

--- a/pkg/backend/options.go
+++ b/pkg/backend/options.go
@@ -21,6 +21,7 @@ type Option func(*Options)
 type Options struct {
 	plainHTTP bool
 	proxy     string
+	insecure  bool
 	output    string
 }
 
@@ -35,6 +36,13 @@ func WithPlainHTTP() Option {
 func WithProxy(proxy string) Option {
 	return func(opts *Options) {
 		opts.proxy = proxy
+	}
+}
+
+// WithInsecure sets the insecure option.
+func WithInsecure(insecure bool) Option {
+	return func(opts *Options) {
+		opts.insecure = insecure
 	}
 }
 

--- a/pkg/backend/pull.go
+++ b/pkg/backend/pull.go
@@ -18,6 +18,7 @@ package backend
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -70,6 +71,9 @@ func (b *backend) Pull(ctx context.Context, target string, opts ...Option) error
 
 		httpClient.Transport = &http.Transport{
 			Proxy: http.ProxyURL(proxyURL),
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: options.insecure,
+			},
 		}
 	}
 

--- a/pkg/config/pull.go
+++ b/pkg/config/pull.go
@@ -19,6 +19,7 @@ package config
 type Pull struct {
 	PlainHTTP  bool
 	Proxy      string
+	Insecure   bool
 	ExtractDir string
 }
 
@@ -26,6 +27,7 @@ func NewPull() *Pull {
 	return &Pull{
 		PlainHTTP:  false,
 		Proxy:      "",
+		Insecure:   false,
 		ExtractDir: "",
 	}
 }


### PR DESCRIPTION
This pull request introduces a new feature to allow insecure connections for the pull operation by adding an option to skip TLS verification. The most important changes include updates to command flags, backend options, and the pull configuration.

### Command Flags Updates:
* [`cmd/pull.go`](diffhunk://#diff-d083b2621fc1453b30bfe075a3f58f2844ed7b124a62e0a86c284290d00511e4R49): Added a new flag `--insecure` to use an insecure connection and skip TLS verification.

### Backend Options:
* [`pkg/backend/options.go`](diffhunk://#diff-1feaee55567fcf37e5d6098edc81dce8d36eb1952195d38c64d473dbd313bf20R42-R48): Added a new `WithInsecure` option to set the insecure flag in the backend options.

### Pull Configuration:
* [`pkg/config/pull.go`](diffhunk://#diff-da1524afd5700a24c5e4a753564c7597e11e083b80efb1eb4a710758c2398afaR22-R30): Updated the `Pull` struct to include the `Insecure` field and set its default value.

### Pull Operation:
* [`cmd/pull.go`](diffhunk://#diff-d083b2621fc1453b30bfe075a3f58f2844ed7b124a62e0a86c284290d00511e4L68-R69): Modified the `runPull` function to include the `WithInsecure` option when creating backend options.
* [`pkg/backend/pull.go`](diffhunk://#diff-f2435c0ad2b72cf7e41c9392804ffc2c7c29981c749a01127d335d228698ac00R74-R76): Updated the `Pull` method to configure the HTTP client's TLS settings based on the insecure flag.