### PR TITLE
feat: add storage dir for modctl

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -59,7 +59,7 @@ func init() {
 
 // runBuild runs the build modctl.
 func runBuild(ctx context.Context, workDir string) error {
-	b, err := backend.New()
+	b, err := backend.New(rootConfig.StoargeDir)
 	if err != nil {
 		return err
 	}

--- a/cmd/extract.go
+++ b/cmd/extract.go
@@ -54,7 +54,7 @@ func init() {
 
 // runExtract runs the extract modctl.
 func runExtract(ctx context.Context, target string) error {
-	b, err := backend.New()
+	b, err := backend.New(rootConfig.StoargeDir)
 	if err != nil {
 		return err
 	}

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -51,7 +51,7 @@ func init() {
 
 // runInspect runs the inspect modctl.
 func runInspect(ctx context.Context, target string) error {
-	b, err := backend.New()
+	b, err := backend.New(rootConfig.StoargeDir)
 	if err != nil {
 		return err
 	}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -53,7 +53,7 @@ func init() {
 
 // runList runs the list modctl.
 func runList(ctx context.Context) error {
-	b, err := backend.New()
+	b, err := backend.New(rootConfig.StoargeDir)
 	if err != nil {
 		return err
 	}

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -71,7 +71,7 @@ func init() {
 
 // runLogin runs the login modctl.
 func runLogin(ctx context.Context, registry string) error {
-	b, err := backend.New()
+	b, err := backend.New(rootConfig.StoargeDir)
 	if err != nil {
 		return err
 	}

--- a/cmd/logout.go
+++ b/cmd/logout.go
@@ -50,7 +50,7 @@ func init() {
 
 // runLogout runs the logout modctl.
 func runLogout(ctx context.Context, registry string) error {
-	b, err := backend.New()
+	b, err := backend.New(rootConfig.StoargeDir)
 	if err != nil {
 		return err
 	}

--- a/cmd/prune.go
+++ b/cmd/prune.go
@@ -55,7 +55,7 @@ func init() {
 
 // runPrune runs the prune modctl.
 func runPrune(ctx context.Context) error {
-	b, err := backend.New()
+	b, err := backend.New(rootConfig.StoargeDir)
 	if err != nil {
 		return err
 	}

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -57,7 +57,7 @@ func init() {
 
 // runPull runs the pull modctl.
 func runPull(ctx context.Context, target string) error {
-	b, err := backend.New()
+	b, err := backend.New(rootConfig.StoargeDir)
 	if err != nil {
 		return err
 	}

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -54,7 +54,7 @@ func init() {
 
 // runPush runs the push modctl.
 func runPush(ctx context.Context, target string) error {
-	b, err := backend.New()
+	b, err := backend.New(rootConfig.StoargeDir)
 	if err != nil {
 		return err
 	}

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -50,7 +50,7 @@ func init() {
 
 // runRm runs the rm modctl.
 func runRm(ctx context.Context, target string) error {
-	b, err := backend.New()
+	b, err := backend.New(rootConfig.StoargeDir)
 	if err != nil {
 		return err
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,10 +19,13 @@ package cmd
 import (
 	"os"
 
+	"github.com/CloudNativeAI/modctl/pkg/config"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
+
+var rootConfig *config.Root
 
 // rootCmd represents the modctl command.
 var rootCmd = &cobra.Command{
@@ -48,8 +51,15 @@ func Execute() {
 }
 
 func init() {
+	var err error
+	rootConfig, err = config.NewRoot()
+	if err != nil {
+		panic(err)
+	}
+
 	// Bind more cache specific persistent flags.
 	flags := rootCmd.PersistentFlags()
+	flags.StringVar(&rootConfig.StoargeDir, "storage-dir", "", "specify the storage directory for modctl")
 
 	// Bind common flags.
 	if err := viper.BindPFlags(flags); err != nil {

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -61,8 +61,8 @@ type backend struct {
 }
 
 // New creates a new backend.
-func New() (Backend, error) {
-	store, err := storage.New("")
+func New(storageDir string) (Backend, error) {
+	store, err := storage.New("", storageDir)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/config/root.go
+++ b/pkg/config/root.go
@@ -1,0 +1,37 @@
+/*
+ *     Copyright 2024 The CNAI Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import (
+	"os/user"
+	"path/filepath"
+)
+
+type Root struct {
+	StoargeDir string
+}
+
+func NewRoot() (*Root, error) {
+	user, err := user.Current()
+	if err != nil {
+		return nil, err
+	}
+
+	return &Root{
+		StoargeDir: filepath.Join(user.HomeDir, ".modctl"),
+	}, nil
+}

--- a/pkg/storage/factory.go
+++ b/pkg/storage/factory.go
@@ -17,7 +17,6 @@
 package storage
 
 import (
-	"os/user"
 	"path/filepath"
 
 	"github.com/CloudNativeAI/modctl/pkg/storage/distribution"
@@ -25,28 +24,20 @@ import (
 
 const (
 	// contentV1Dir is the content v1 directory.
-	contentV1Dir = "/.modctl/content.v1/"
+	contentV1Dir = "content.v1"
 )
 
 // Type is the type of storage.
 type Type = string
 
 // New gets the storage by the type.
-func New(storageType Type, opts ...Option) (Storage, error) {
+func New(storageType Type, storageDir string, opts ...Option) (Storage, error) {
 	storageOpts := &Options{}
 	for _, opt := range opts {
 		opt(storageOpts)
 	}
-	// apply default option if not set.
-	if storageOpts.RootDir == "" {
-		contentDir, err := GetDefaultContentDir()
-		if err != nil {
-			return nil, err
-		}
 
-		storageOpts.RootDir = contentDir
-	}
-
+	storageOpts.RootDir = filepath.Join(storageDir, contentV1Dir)
 	switch storageType {
 	case distribution.StorageTypeDistribution:
 		return distribution.NewStorage(storageOpts.RootDir)
@@ -56,24 +47,4 @@ func New(storageType Type, opts ...Option) (Storage, error) {
 		//  currently by default we are using distribution as storage.
 		return distribution.NewStorage(storageOpts.RootDir)
 	}
-}
-
-// getHomeDir returns the current user's home directory.
-func getHomeDir() (string, error) {
-	usr, err := user.Current()
-	if err != nil {
-		return "", err
-	}
-
-	return usr.HomeDir, nil
-}
-
-// GetDefaultContentDir returns the default content directory.
-func GetDefaultContentDir() (string, error) {
-	homeDir, err := getHomeDir()
-	if err != nil {
-		return "", err
-	}
-
-	return filepath.Join(homeDir, contentV1Dir), nil
 }


### PR DESCRIPTION
This pull request includes several changes to the `modctl` command-line tool, primarily focusing on configuring and using a storage directory specified by the user. The most important changes include modifying backend initialization to accept a storage directory, updating command files to pass the storage directory, and adding a new configuration package to manage the root configuration.

Backend initialization:

* [`pkg/backend/backend.go`](diffhunk://#diff-c65bcfe9bb457434c3e69ba3f0576d7669935f350d24e2c2c58b05b4f9c510b2L64-R65): Modified the `New` function to accept a `storageDir` parameter.
* [`pkg/storage/factory.go`](diffhunk://#diff-a0f350ad9b077568317808a605403162b85e380ceb375d220b5c03b7d2cd461fL20-R40): Updated the `New` function to accept a `storageDir` parameter and removed default content directory functions. [[1]](diffhunk://#diff-a0f350ad9b077568317808a605403162b85e380ceb375d220b5c03b7d2cd461fL20-R40) [[2]](diffhunk://#diff-a0f350ad9b077568317808a605403162b85e380ceb375d220b5c03b7d2cd461fL60-L79)

Command file updates:

* `cmd/build.go`, `cmd/extract.go`, `cmd/inspect.go`, `cmd/list.go`, `cmd/login.go`, `cmd/logout.go`, `cmd/prune.go`, `cmd/pull.go`, `cmd/push.go`, `cmd/rm.go`: Updated the backend initialization to pass `rootConfig.StoargeDir` as the storage directory. [[1]](diffhunk://#diff-5794c40aa4c9301aaf9c39eacf7d3c8511f2511cb24bdd95e0a08704ba583a5fL62-R62) [[2]](diffhunk://#diff-9f2686b547b30e73afab14ac98ce0450e38f605a198cb2b2ea953b93f27751fcL57-R57) [[3]](diffhunk://#diff-e1112a72d67ea1111e0c19d52bd341c23830344021f7f8534ffa74df2ad51d20L54-R54) [[4]](diffhunk://#diff-2cb6b39b26188bd68fce779dd82957aa4b969400c8a1554746a19f388924d9e5L56-R56) [[5]](diffhunk://#diff-4e497e80de2b0f5468ea1ef74dc7ed5e6eaa10c8808c8a463878a9a9ec79799dL74-R74) [[6]](diffhunk://#diff-bb1897c585979dfcef1410c22c884bce52e511cf478d7de518cdb912ab28b003L53-R53) [[7]](diffhunk://#diff-1c4061944cc223530f04ff22f54f259e7a1517bfe15dbf63728ec7074f1d54a6L58-R58) [[8]](diffhunk://#diff-d083b2621fc1453b30bfe075a3f58f2844ed7b124a62e0a86c284290d00511e4L60-R60) [[9]](diffhunk://#diff-e8011aeef8362327cdc0e4492778f39d0eb835e4cafe821111e3446637cc862eL57-R57) [[10]](diffhunk://#diff-8948c5a258a947160c86c50242b8319d5be9a5ee3895e14a743ee09999661544L53-R53)

Configuration management:

* [`cmd/root.go`](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR22-R29): Introduced a new `rootConfig` variable and initialized it with the `NewRoot` function from the new `config` package. Added a persistent flag for specifying the storage directory. [[1]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR22-R29) [[2]](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR54-R62)
* [`pkg/config/root.go`](diffhunk://#diff-53d0b44d411a6bf6af7ce1c3664663057522b69d13da5769fe434605aac20817R1-R37): Added a new `config` package with a `Root` struct to manage the storage directory configuration.