### PR TITLE
feat: add default storage dir for modctl

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -59,7 +59,7 @@ func init() {
 
 	// Bind more cache specific persistent flags.
 	flags := rootCmd.PersistentFlags()
-	flags.StringVar(&rootConfig.StoargeDir, "storage-dir", "", "specify the storage directory for modctl")
+	flags.StringVar(&rootConfig.StoargeDir, "storage-dir", rootConfig.StoargeDir, "specify the storage directory for modctl")
 
 	// Bind common flags.
 	if err := viper.BindPFlags(flags); err != nil {


### PR DESCRIPTION
This pull request makes a small but important change to the `cmd/root.go` file. The change ensures that the `storage-dir` flag for `modctl` has a default value by setting it to the current value of `rootConfig.StoargeDir`.

* [`cmd/root.go`](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL62-R62): Modified the `storage-dir` flag to use `rootConfig.StoargeDir` as the default value.