### PR TITLE
feat: change defaultPullConcurrency and defaultPushConcurrency to 5

### DIFF
--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -49,7 +49,7 @@ var pullCmd = &cobra.Command{
 // init initializes pull command.
 func init() {
 	flags := pullCmd.Flags()
-	flags.IntVar(&pullConfig.Concurrency, "concurrency", pullConfig.Concurrency, "specify the number of concurrent pull operations (default: 3)")
+	flags.IntVar(&pullConfig.Concurrency, "concurrency", pullConfig.Concurrency, "specify the number of concurrent pull operations")
 	flags.BoolVar(&pullConfig.PlainHTTP, "plain-http", false, "use plain HTTP instead of HTTPS")
 	flags.BoolVar(&pullConfig.Insecure, "insecure", false, "use insecure connection for the pull operation and skip TLS verification")
 	flags.StringVar(&pullConfig.Proxy, "proxy", "", "use proxy for the pull operation")

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -27,7 +27,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-var pushConfig = config.NewPull()
+var pushConfig = config.NewPush()
 
 // pushCmd represents the modctl command for push.
 var pushCmd = &cobra.Command{
@@ -49,7 +49,7 @@ var pushCmd = &cobra.Command{
 // init initializes push command.
 func init() {
 	flags := pushCmd.Flags()
-	flags.IntVar(&pushConfig.Concurrency, "concurrency", pushConfig.Concurrency, "specify the number of concurrent push operations (default: 3)")
+	flags.IntVar(&pushConfig.Concurrency, "concurrency", pushConfig.Concurrency, "specify the number of concurrent push operations")
 	flags.BoolVar(&pushConfig.PlainHTTP, "plain-http", false, "use plain HTTP instead of HTTPS")
 
 	if err := viper.BindPFlags(flags); err != nil {

--- a/pkg/config/pull.go
+++ b/pkg/config/pull.go
@@ -20,7 +20,7 @@ import "fmt"
 
 const (
 	// defaultPullConcurrency is the default number of concurrent pull operations.
-	defaultPullConcurrency = 3
+	defaultPullConcurrency = 5
 )
 
 type Pull struct {

--- a/pkg/config/push.go
+++ b/pkg/config/push.go
@@ -20,7 +20,7 @@ import "fmt"
 
 const (
 	// defaultPushConcurrency is the default number of concurrent push operations.
-	defaultPushConcurrency = 3
+	defaultPushConcurrency = 5
 )
 
 type Push struct {


### PR DESCRIPTION
This pull request includes changes to the concurrency settings and variable initialization for push and pull operations in the configuration files. The most important changes are as follows:

Concurrency settings:

* [`pkg/config/pull.go`](diffhunk://#diff-da1524afd5700a24c5e4a753564c7597e11e083b80efb1eb4a710758c2398afaL23-R23): Increased the default number of concurrent pull operations from 3 to 5.
* [`pkg/config/push.go`](diffhunk://#diff-7bc49abf8a6d1070cf8e9b2a0c971a719626d67c9ad709ea95bd432eddaa5644L23-R23): Increased the default number of concurrent push operations from 3 to 5.

Variable initialization:

* [`cmd/push.go`](diffhunk://#diff-e8011aeef8362327cdc0e4492778f39d0eb835e4cafe821111e3446637cc862eL30-R30): Changed the initialization of `pushConfig` from `config.NewPull()` to `config.NewPush()`.