### PR TITLE
fix: fix progress bar stuck when error occurred during pull/push

### DIFF
--- a/pkg/backend/progress.go
+++ b/pkg/backend/progress.go
@@ -105,6 +105,17 @@ func (p *ProgressBar) PrintMessage(prompt string, desc ocispec.Descriptor, messa
 	p.bars[desc.Digest.String()] = bar
 }
 
+// Abort aborts the progress bar by the given desc.
+func (p *ProgressBar) Abort(desc ocispec.Descriptor) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	// if the bar already exists, abort it.
+	bar, ok := p.bars[desc.Digest.String()]
+	if ok {
+		bar.Abort(false)
+	}
+}
+
 // Wait waits for the progress bar to finish.
 func (p *ProgressBar) Wait() {
 	p.mpb.Wait()

--- a/pkg/backend/pull.go
+++ b/pkg/backend/pull.go
@@ -163,6 +163,7 @@ func pullIfNotExist(ctx context.Context, pb *ProgressBar, prompt string, src *re
 	if desc.MediaType == ocispec.MediaTypeImageManifest {
 		body, err := io.ReadAll(pb.Add(prompt, desc, content))
 		if err != nil {
+			pb.Abort(desc)
 			return fmt.Errorf("failed to read the manifest: %w", err)
 		}
 
@@ -171,6 +172,7 @@ func pullIfNotExist(ctx context.Context, pb *ProgressBar, prompt string, src *re
 		}
 	} else {
 		if _, _, err := dst.PushBlob(ctx, repo, pb.Add(prompt, desc, content)); err != nil {
+			pb.Abort(desc)
 			return err
 		}
 	}

--- a/pkg/backend/push.go
+++ b/pkg/backend/push.go
@@ -142,6 +142,7 @@ func pushIfNotExist(ctx context.Context, pb *ProgressBar, prompt string, src sto
 		}
 
 		if err := dst.Manifests().Push(ctx, desc, pb.Add(prompt, desc, bytes.NewReader(manifestRaw))); err != nil {
+			pb.Abort(desc)
 			return err
 		}
 
@@ -159,6 +160,7 @@ func pushIfNotExist(ctx context.Context, pb *ProgressBar, prompt string, src sto
 		defer content.Close()
 
 		if err := dst.Blobs().Push(ctx, desc, pb.Add(prompt, desc, content)); err != nil {
+			pb.Abort(desc)
 			return err
 		}
 	}


### PR DESCRIPTION
This pull request introduces an `Abort` method to the `ProgressBar` class and integrates it into various error handling scenarios within the `pullIfNotExist` and `pushIfNotExist` functions. The most important changes include the addition of the `Abort` method and its usage to handle errors more gracefully by aborting the progress bar when an error occurs.

Enhancements to error handling:

* [`pkg/backend/progress.go`](diffhunk://#diff-3e071d439de18fe4e494264841f0ea962b4d587a878e5af3761bea3f723c323fR108-R118): Added a new `Abort` method to the `ProgressBar` class to abort the progress bar for a given descriptor.

Integration of the `Abort` method in error scenarios:

* [`pkg/backend/pull.go`](diffhunk://#diff-f2435c0ad2b72cf7e41c9392804ffc2c7c29981c749a01127d335d228698ac00R166): Updated the `pullIfNotExist` function to call `pb.Abort(desc)` when reading the manifest fails.
* [`pkg/backend/pull.go`](diffhunk://#diff-f2435c0ad2b72cf7e41c9392804ffc2c7c29981c749a01127d335d228698ac00R175): Updated the `pullIfNotExist` function to call `pb.Abort(desc)` when pushing a blob fails.
* [`pkg/backend/push.go`](diffhunk://#diff-9dcd5308044bc9473f04358490f28c6748ec7bcf3cfa52058ef2756fb495846fR145): Updated the `pushIfNotExist` function to call `pb.Abort(desc)` when pushing the manifest fails.
* [`pkg/backend/push.go`](diffhunk://#diff-9dcd5308044bc9473f04358490f28c6748ec7bcf3cfa52058ef2756fb495846fR163): Updated the `pushIfNotExist` function to call `pb.Abort(desc)` when pushing a blob fails.