### PR TITLE
refactor: change regex match to the glob path pattern

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -46,20 +46,14 @@ PRECISION bf16
 # Model quantization (string), such as awq, gptq, etc.
 QUANTIZATION awq
 
-# Specify model configuration file.
+# Specify model configuration file, support glob path pattern.
 CONFIG config.json
 
-# Specify model configuration file.
+# Specify model configuration file, support glob path pattern.
 CONFIG generation_config.json
 
-# Model weight.
-MODEL \.safetensors$
-
-# Model code.
-CODE \.py$
-
-# Model dataset.
-DATASET \.csv$
+# Model weight, support glob path pattern.
+MODEL *.safetensors
 ```
 
 Then run the following command to build the model artifact:

--- a/pkg/backend/build/build.go
+++ b/pkg/backend/build/build.go
@@ -36,7 +36,7 @@ import (
 )
 
 // BuildLayer converts the file to the image blob and push it to the storage.
-func BuildLayer(ctx context.Context, store storage.Storage, mediaType, repo, path, workDir string) (ocispec.Descriptor, error) {
+func BuildLayer(ctx context.Context, store storage.Storage, mediaType, workDir, repo, path string) (ocispec.Descriptor, error) {
 	reader, err := archiver.Tar(path)
 	if err != nil {
 		return ocispec.Descriptor{}, fmt.Errorf("failed to tar file: %w", err)

--- a/pkg/backend/build_test.go
+++ b/pkg/backend/build_test.go
@@ -29,11 +29,12 @@ func TestGetProcessors(t *testing.T) {
 	modelfile.On("GetConfigs").Return([]string{"config1", "config2"})
 	modelfile.On("GetModels").Return([]string{"model1", "model2"})
 
-	processors := getProcessors(modelfile)
+	b := &backend{}
+	processors := b.getProcessors(modelfile)
 
 	assert.Len(t, processors, 4)
-	assert.Equal(t, "license", processors[0].Name())
-	assert.Equal(t, "readme", processors[1].Name())
+	assert.Equal(t, "readme", processors[0].Name())
+	assert.Equal(t, "license", processors[1].Name())
 	assert.Equal(t, "model_config", processors[2].Name())
 	assert.Equal(t, "model", processors[3].Name())
 }

--- a/pkg/backend/processor/base.go
+++ b/pkg/backend/processor/base.go
@@ -1,0 +1,69 @@
+/*
+ *     Copyright 2025 The CNAI Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package processor
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/CloudNativeAI/modctl/pkg/backend/build"
+	"github.com/CloudNativeAI/modctl/pkg/storage"
+
+	humanize "github.com/dustin/go-humanize"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+type base struct {
+	// store is the underlying storage backend.
+	store storage.Storage
+	// mediaType is the media type of the processed content.
+	mediaType string
+	// patterns is the list of patterns to match.
+	patterns []string
+}
+
+// Process implements the Processor interface, which can be reused by other processors.
+func (b *base) Process(ctx context.Context, workDir, repo string) ([]ocispec.Descriptor, error) {
+	absWorkDir, err := filepath.Abs(workDir)
+	if err != nil {
+		return nil, err
+	}
+
+	var matchedPaths []string
+	for _, pattern := range b.patterns {
+		matches, err := filepath.Glob(filepath.Join(absWorkDir, pattern))
+		if err != nil {
+			return nil, err
+		}
+
+		matchedPaths = append(matchedPaths, matches...)
+	}
+
+	var descriptors []ocispec.Descriptor
+	for _, path := range matchedPaths {
+		desc, err := build.BuildLayer(ctx, b.store, b.mediaType, workDir, repo, path)
+		if err != nil {
+			return nil, err
+		}
+
+		fmt.Printf("%-15s => %s (%s)\n", "Built blob", desc.Digest, humanize.IBytes(uint64(desc.Size)))
+		descriptors = append(descriptors, desc)
+	}
+
+	return descriptors, nil
+}

--- a/pkg/backend/processor/license.go
+++ b/pkg/backend/processor/license.go
@@ -18,36 +18,31 @@ package processor
 
 import (
 	"context"
-	"os"
 
-	"github.com/CloudNativeAI/modctl/pkg/backend/build"
 	"github.com/CloudNativeAI/modctl/pkg/storage"
-	modelspec "github.com/CloudNativeAI/model-spec/specs-go/v1"
-
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // NewLicenseProcessor creates a new LICENSE processor.
-func NewLicenseProcessor() Processor {
-	return &licenseProcessor{}
+func NewLicenseProcessor(store storage.Storage, mediaType string, patterns []string) Processor {
+	return &licenseProcessor{
+		base: &base{
+			store:     store,
+			mediaType: mediaType,
+			patterns:  patterns,
+		},
+	}
 }
 
 // licenseProcessor is the processor to process the LICENSE file.
-type licenseProcessor struct{}
+type licenseProcessor struct {
+	base *base
+}
 
 func (p *licenseProcessor) Name() string {
 	return "license"
 }
 
-func (p *licenseProcessor) Identify(_ context.Context, path string, info os.FileInfo) bool {
-	return info.Name() == "LICENSE" || info.Name() == "LICENSE.txt"
-}
-
-func (p *licenseProcessor) Process(ctx context.Context, store storage.Storage, repo, path, workDir string) (ocispec.Descriptor, error) {
-	desc, err := build.BuildLayer(ctx, store, modelspec.MediaTypeModelDoc, repo, path, workDir)
-	if err != nil {
-		return ocispec.Descriptor{}, err
-	}
-
-	return desc, nil
+func (p *licenseProcessor) Process(ctx context.Context, workDir, repo string) ([]ocispec.Descriptor, error) {
+	return p.base.Process(ctx, workDir, repo)
 }

--- a/pkg/backend/processor/license_test.go
+++ b/pkg/backend/processor/license_test.go
@@ -18,54 +18,52 @@ package processor
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
-	"testing/fstest"
 
 	"github.com/CloudNativeAI/modctl/test/mocks/storage"
 	modelspec "github.com/CloudNativeAI/model-spec/specs-go/v1"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
 )
 
-func TestLicenseProcessor_Name(t *testing.T) {
-	p := NewLicenseProcessor()
-	assert.Equal(t, "license", p.Name())
+type licenseProcessorSuite struct {
+	suite.Suite
+	mockStore *storage.Storage
+	processor Processor
+	workDir   string
 }
 
-func TestLicenseProcessor_Identify(t *testing.T) {
-	p := NewLicenseProcessor()
-	mockFS := fstest.MapFS{
-		"LICENSE":     &fstest.MapFile{},
-		"LICENSE.txt": &fstest.MapFile{},
-		"README.md":   &fstest.MapFile{},
+func (s *licenseProcessorSuite) SetupTest() {
+	s.mockStore = &storage.Storage{}
+	s.processor = NewLicenseProcessor(s.mockStore, modelspec.MediaTypeModelDoc, []string{"LICENSE"})
+	// generate test files for prorcess.
+	s.workDir = s.Suite.T().TempDir()
+	if err := os.WriteFile(filepath.Join(s.workDir, "LICENSE"), []byte(""), 0644); err != nil {
+		s.Suite.T().Fatal(err)
 	}
-	info, err := mockFS.Stat("LICENSE")
-	assert.NoError(t, err)
-	assert.True(t, p.Identify(context.Background(), "LICENSE", info))
-
-	info, err = mockFS.Stat("LICENSE.txt")
-	assert.NoError(t, err)
-	assert.True(t, p.Identify(context.Background(), "LICENSE.txt", info))
-
-	info, err = mockFS.Stat("README.md")
-	assert.NoError(t, err)
-	assert.False(t, p.Identify(context.Background(), "README.md", info))
 }
 
-func TestLicenseProcessor_Process(t *testing.T) {
-	p := NewLicenseProcessor()
+func (s *licenseProcessorSuite) TestName() {
+	assert.Equal(s.Suite.T(), "license", s.processor.Name())
+}
+
+func (s *licenseProcessorSuite) TestProcess() {
 	ctx := context.Background()
-	mockStore := &storage.Storage{}
 	repo := "test-repo"
-	path := "/tmp/LICENSE"
+	s.mockStore.On("PushBlob", ctx, repo, mock.Anything).Return("sha256:1234567890abcdef", int64(1024), nil)
 
-	mockStore.On("PushBlob", ctx, repo, mock.Anything).Return("sha256:1234567890abcdef", int64(1024), nil)
+	desc, err := s.processor.Process(ctx, s.workDir, repo)
+	assert.NoError(s.Suite.T(), err)
+	assert.NotNil(s.Suite.T(), desc)
+	assert.Equal(s.Suite.T(), "sha256:1234567890abcdef", desc[0].Digest.String())
+	assert.Equal(s.Suite.T(), int64(1024), desc[0].Size)
+	assert.Equal(s.Suite.T(), "LICENSE", desc[0].Annotations[modelspec.AnnotationFilepath])
+}
 
-	desc, err := p.Process(ctx, mockStore, repo, path, "/tmp")
-	assert.NoError(t, err)
-	assert.NotNil(t, desc)
-	assert.Equal(t, "sha256:1234567890abcdef", desc.Digest.String())
-	assert.Equal(t, int64(1024), desc.Size)
-	assert.Equal(t, "LICENSE", desc.Annotations[modelspec.AnnotationFilepath])
+func TestLicenseProcessorSuite(t *testing.T) {
+	suite.Run(t, new(licenseProcessorSuite))
 }

--- a/pkg/backend/processor/processor.go
+++ b/pkg/backend/processor/processor.go
@@ -18,9 +18,6 @@ package processor
 
 import (
 	"context"
-	"os"
-
-	"github.com/CloudNativeAI/modctl/pkg/storage"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
@@ -29,9 +26,6 @@ import (
 type Processor interface {
 	// Name returns the name of the processor.
 	Name() string
-	// Identify identifies the file, returns true if the file is identified,
-	// then the Process will be called to process the file, otherwise it will be skipped.
-	Identify(ctx context.Context, path string, info os.FileInfo) bool
 	// Process processes the file.
-	Process(ctx context.Context, store storage.Storage, repo, path, workDir string) (ocispec.Descriptor, error)
+	Process(ctx context.Context, workDir, repo string) ([]ocispec.Descriptor, error)
 }

--- a/pkg/backend/processor/readme.go
+++ b/pkg/backend/processor/readme.go
@@ -18,36 +18,32 @@ package processor
 
 import (
 	"context"
-	"os"
 
-	"github.com/CloudNativeAI/modctl/pkg/backend/build"
 	"github.com/CloudNativeAI/modctl/pkg/storage"
-	modelspec "github.com/CloudNativeAI/model-spec/specs-go/v1"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // NewReadmeProcessor creates a new README processor.
-func NewReadmeProcessor() Processor {
-	return &readmeProcessor{}
+func NewReadmeProcessor(store storage.Storage, mediaType string, patterns []string) Processor {
+	return &readmeProcessor{
+		base: &base{
+			store:     store,
+			mediaType: mediaType,
+			patterns:  patterns,
+		},
+	}
 }
 
 // readmeProcessor is the processor to process the README file.
-type readmeProcessor struct{}
+type readmeProcessor struct {
+	base *base
+}
 
 func (p *readmeProcessor) Name() string {
 	return "readme"
 }
 
-func (p *readmeProcessor) Identify(_ context.Context, path string, info os.FileInfo) bool {
-	return info.Name() == "README.md" || info.Name() == "README"
-}
-
-func (p *readmeProcessor) Process(ctx context.Context, store storage.Storage, repo, path, workDir string) (ocispec.Descriptor, error) {
-	desc, err := build.BuildLayer(ctx, store, modelspec.MediaTypeModelDoc, repo, path, workDir)
-	if err != nil {
-		return ocispec.Descriptor{}, err
-	}
-
-	return desc, nil
+func (p *readmeProcessor) Process(ctx context.Context, workDir, repo string) ([]ocispec.Descriptor, error) {
+	return p.base.Process(ctx, workDir, repo)
 }

--- a/pkg/backend/processor/readme_test.go
+++ b/pkg/backend/processor/readme_test.go
@@ -18,54 +18,52 @@ package processor
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
-	"testing/fstest"
 
 	"github.com/CloudNativeAI/modctl/test/mocks/storage"
 	modelspec "github.com/CloudNativeAI/model-spec/specs-go/v1"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
 )
 
-func TestReadmeProcessor_Name(t *testing.T) {
-	p := NewReadmeProcessor()
-	assert.Equal(t, "readme", p.Name())
+type readmeProcessorSuite struct {
+	suite.Suite
+	mockStore *storage.Storage
+	processor Processor
+	workDir   string
 }
 
-func TestReadmeProcessor_Identify(t *testing.T) {
-	p := NewReadmeProcessor()
-	mockFS := fstest.MapFS{
-		"README":    &fstest.MapFile{},
-		"README.md": &fstest.MapFile{},
-		"LICENSE":   &fstest.MapFile{},
+func (s *readmeProcessorSuite) SetupTest() {
+	s.mockStore = &storage.Storage{}
+	s.processor = NewReadmeProcessor(s.mockStore, modelspec.MediaTypeModelWeight, []string{"README"})
+	// generate test files for prorcess.
+	s.workDir = s.Suite.T().TempDir()
+	if err := os.WriteFile(filepath.Join(s.workDir, "README"), []byte(""), 0644); err != nil {
+		s.Suite.T().Fatal(err)
 	}
-	info, err := mockFS.Stat("README")
-	assert.NoError(t, err)
-	assert.True(t, p.Identify(context.Background(), "README", info))
-
-	info, err = mockFS.Stat("README.md")
-	assert.NoError(t, err)
-	assert.True(t, p.Identify(context.Background(), "README.md", info))
-
-	info, err = mockFS.Stat("LICENSE")
-	assert.NoError(t, err)
-	assert.False(t, p.Identify(context.Background(), "LICENSE", info))
 }
 
-func TestReadmeProcessor_Process(t *testing.T) {
-	p := NewReadmeProcessor()
+func (s *readmeProcessorSuite) TestName() {
+	assert.Equal(s.Suite.T(), "readme", s.processor.Name())
+}
+
+func (s *readmeProcessorSuite) TestProcess() {
 	ctx := context.Background()
-	mockStore := &storage.Storage{}
 	repo := "test-repo"
-	path := "/tmp/README"
+	s.mockStore.On("PushBlob", ctx, repo, mock.Anything).Return("sha256:1234567890abcdef", int64(1024), nil)
 
-	mockStore.On("PushBlob", ctx, repo, mock.Anything).Return("sha256:1234567890abcdef", int64(1024), nil)
+	desc, err := s.processor.Process(ctx, s.workDir, repo)
+	assert.NoError(s.Suite.T(), err)
+	assert.NotNil(s.Suite.T(), desc)
+	assert.Equal(s.Suite.T(), "sha256:1234567890abcdef", desc[0].Digest.String())
+	assert.Equal(s.Suite.T(), int64(1024), desc[0].Size)
+	assert.Equal(s.Suite.T(), "README", desc[0].Annotations[modelspec.AnnotationFilepath])
+}
 
-	desc, err := p.Process(ctx, mockStore, repo, path, "/tmp")
-	assert.NoError(t, err)
-	assert.NotNil(t, desc)
-	assert.Equal(t, "sha256:1234567890abcdef", desc.Digest.String())
-	assert.Equal(t, int64(1024), desc.Size)
-	assert.Equal(t, "README", desc.Annotations[modelspec.AnnotationFilepath])
+func TestReadmeProcessorSuite(t *testing.T) {
+	suite.Run(t, new(readmeProcessorSuite))
 }


### PR DESCRIPTION
This pull request includes significant changes to the `backend` package, focusing on refactoring the processor logic and improving the `Build` function. The most important changes include the introduction of a `base` struct for processors, modifications to the `Build` function, and updates to the processor implementations and their corresponding tests.

### Refactoring and Enhancements:

* **Introduction of `base` struct for processors:**
  - Added a new `base` struct in `pkg/backend/processor/base.go` to handle common processor logic, including the `Process` method.
  - Updated `licenseProcessor`, `modelProcessor`, and `modelConfigProcessor` to utilize the new `base` struct for processing files. [[1]](diffhunk://#diff-8e6a212f2835c8e287099fa0b13b281f6c553a865fe0c7672d92562cddce36afL21-R47) [[2]](diffhunk://#diff-3c93b729e6787a645097acefc2f9f35fce8eac1804b001502c8e99e01e7b919aL21-R48) [[3]](diffhunk://#diff-762833d1b5969b48cac05655bf5ac031ea3fba9ba04bdfbf04cd47476f02a9b7L21-R48)

* **Modifications to the `Build` function:**
  - Changed the `defaultProcessors` and `getProcessors` methods to be part of the `backend` struct, allowing them to access the `store` and other members.
  - Updated the `process` method to simplify file processing by removing the directory walking logic and using the `Process` method of each processor.

* **Updates to processor implementations:**
  - Refactored `NewLicenseProcessor`, `NewModelProcessor`, and `NewModelConfigProcessor` to accept `store`, `mediaType`, and `patterns` parameters, and to use the `base` struct for processing. [[1]](diffhunk://#diff-8e6a212f2835c8e287099fa0b13b281f6c553a865fe0c7672d92562cddce36afL21-R47) [[2]](diffhunk://#diff-3c93b729e6787a645097acefc2f9f35fce8eac1804b001502c8e99e01e7b919aL21-R48) [[3]](diffhunk://#diff-762833d1b5969b48cac05655bf5ac031ea3fba9ba04bdfbf04cd47476f02a9b7L21-R48)

### Testing Improvements:

* **Processor tests refactoring:**
  - Updated tests for `licenseProcessor`, `modelProcessor`, and `modelConfigProcessor` to use the `suite` package for better test organization and setup. [[1]](diffhunk://#diff-0a11f0e31ef57f55c344e6a9bfe5b8ae2933c4dac716ccf4ea513b478a2bd889R21-R68) [[2]](diffhunk://#diff-3bf0ae03636ebc855ae9fd6b666cc9c651b3b8644966a09f22d34d44d6aa7113R21-R68) [[3]](diffhunk://#diff-e25d3ac4678fe0acdc9b3a72938e1a8b74477630e2aa911d0dbaa18716a4d8a8R21-R68)
  - Modified test cases to reflect the changes in processor initialization and processing logic.

### Additional Changes:

* **Imports and minor adjustments:**
  - Removed unused imports and reorganized import statements in various files. [[1]](diffhunk://#diff-d6967c304021925580fe39f08821dc9e301bcc02a119e188d723e6939f170a5cL22-R27) [[2]](diffhunk://#diff-337d5a87c7d0737852f309569b558982ebd1fe954eca7a7c1c0ec6f0538fd294L21-L23)
  - Adjusted the parameter order in the `BuildLayer` function to maintain consistency.