### PR TITLE
chore: add maintainers for nfpms in .goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,7 +7,7 @@ before:
     - go mod download
 
 builds:
-  - main: ./cmd/main.go
+  - main: main.go
     id: modctl
     binary: modctl
     goos:
@@ -39,6 +39,7 @@ changelog:
 
 nfpms:
   - id: modctl
+    maintainer: Model Spec Maintainers <model-spec-maintainers@googlegroups.com>
     file_name_template: "modctl-{{ .Version }}-{{ .Os }}-{{ .Arch }}"
     package_name: modctl
     description: A command line tool for managing artifact bundled based on the Model Format Specification


### PR DESCRIPTION
This pull request includes a small change to the `.goreleaser.yml` file. The change specifies the maintainer for the `modctl` package. 

* [`.goreleaser.yml`](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689R42): Added `Model Spec Maintainers <model-spec-maintainers@googlegroups.com>` as the maintainer for the `modctl` package.