### PR TITLE
feat: add version command for modctl

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,6 +16,12 @@ builds:
     goarch:
       - amd64
       - arm64
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -X github.com/CloudNativeAI/modctl/pkg/version.GitVersion={{ .Tag }}
+      - -X github.com/CloudNativeAI/modctl/pkg/version.GitCommit={{ .ShortCommit }}
+      - -X github.com/CloudNativeAI/modctl/pkg/version.BuildTime={{ .Date }}
 
 archives:
   - name_template: "modctl-{{ .Version }}-{{ .Os }}-{{ .Arch }}"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -67,6 +67,7 @@ func init() {
 	}
 
 	// Add sub command.
+	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(buildCmd)
 	rootCmd.AddCommand(listCmd)
 	rootCmd.AddCommand(loginCmd)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,56 @@
+/*
+ *     Copyright 2025 The CNAI Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/CloudNativeAI/modctl/pkg/version"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// versionCmd represents the modctl command for version.
+var versionCmd = &cobra.Command{
+	Use:                "version",
+	Short:              "A command line tool for modctl version",
+	DisableAutoGenTag:  true,
+	SilenceUsage:       true,
+	FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runVersion()
+	},
+}
+
+// init initializes version command.
+func init() {
+	flags := rmCmd.Flags()
+
+	if err := viper.BindPFlags(flags); err != nil {
+		panic(fmt.Errorf("bind version flags to viper: %w", err))
+	}
+}
+
+// runVersion runs the version modctl.
+func runVersion() error {
+	fmt.Printf("%-12s%s\n", "Version:", version.GitVersion)
+	fmt.Printf("%-12s%s\n", "Commit:", version.GitCommit)
+	fmt.Printf("%-12s%s\n", "Platform:", version.Platform)
+	fmt.Printf("%-12s%s\n", "BuildTime:", version.BuildTime)
+	return nil
+}

--- a/pkg/version/platform_darwin.go
+++ b/pkg/version/platform_darwin.go
@@ -1,0 +1,19 @@
+/*
+ *     Copyright 2025 The CNAI Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package version
+
+const platform = "darwin"

--- a/pkg/version/platform_linux.go
+++ b/pkg/version/platform_linux.go
@@ -1,0 +1,19 @@
+/*
+ *     Copyright 2025 The CNAI Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package version
+
+const platform = "linux"

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,24 @@
+/*
+ *     Copyright 2025 The CNAI Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package version
+
+var (
+	GitVersion = "v0.0.1"
+	GitCommit  = "unknown"
+	Platform   = platform
+	BuildTime  = "unknown"
+)


### PR DESCRIPTION
This pull request includes multiple changes to the `modctl` project, focusing on adding version information, initializing a new command, and updating build configurations. The most important changes include the addition of the `version` command, updates to `pkg/version` files, and modifications to the `.goreleaser.yml` configuration.

### New Command Addition:
* Added `versionCmd` to `cmd/version.go` to display version information, including Git version, commit, platform, and build time. (`[cmd/version.goR1-R56](diffhunk://#diff-7cb26babce207ed9c17e9dd3ead0b66d204da3cf4d11649412c197defbb3029cR1-R56)`)
* Included `versionCmd` in the root command initialization in `cmd/root.go`. (`[cmd/root.goR70](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR70)`)

### Version Information:
* Created `pkg/version/platform_darwin.go` and `pkg/version/platform_linux.go` to define platform constants. (`[[1]](diffhunk://#diff-0f944bd167e91f02df989b366824c5f8880c9a158380cc2d09ded98e43b99947R1-R19)`, `[[2]](diffhunk://#diff-87db55b1dee1e55a5b8a861ddeaf61f1e229f7d27e36d1a4d01ac89c87218907R1-R19)`)
* Added version variables (`GitVersion`, `GitCommit`, `Platform`, `BuildTime`) in `pkg/version/version.go`. (`[pkg/version/version.goR1-R24](diffhunk://#diff-73b8ec8a05213857da6e9598e34c5d7a18a6e5349250908ae6710578236977f2R1-R24)`)

### Build Configuration:
* Updated `.goreleaser.yml` to include environment variables and linker flags for version information. (`[.goreleaser.ymlR19-R28](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689R19-R28)`)
* Changed `checksum` configuration in `.goreleaser.yml` to use `name_template` instead of `version_template`. (`[.goreleaser.ymlL31-R37](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689L31-R37)`)