### PR TITLE
fix: add the directory info to the tar header

### DIFF
--- a/pkg/archiver/archiver.go
+++ b/pkg/archiver/archiver.go
@@ -25,63 +25,115 @@ import (
 	"strings"
 )
 
-// Tar tars the target file and return the content by stream.
-func Tar(path string) (io.Reader, error) {
+// Tar creates a tar archive of the specified path (file or directory)
+// and returns the content as a stream. For individual files, it preserves
+// the directory structure relative to the working directory.
+func Tar(srcPath string, workDir string) (io.Reader, error) {
 	pr, pw := io.Pipe()
+
 	go func() {
 		defer pw.Close()
-		// create the tar writer.
 		tw := tar.NewWriter(pw)
 		defer tw.Close()
 
-		file, err := os.Open(path)
+		info, err := os.Stat(srcPath)
 		if err != nil {
-			pw.CloseWithError(fmt.Errorf("failed to open file: %w", err))
+			pw.CloseWithError(fmt.Errorf("failed to stat source path: %w", err))
 			return
 		}
 
-		defer file.Close()
-		info, err := file.Stat()
-		if err != nil {
-			pw.CloseWithError(fmt.Errorf("failed to stat file: %w", err))
-			return
-		}
+		// Handle directories and files differently.
+		if info.IsDir() {
+			// For directories, walk through and add all files/subdirs.
+			err = filepath.Walk(srcPath, func(path string, info os.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
 
-		header, err := tar.FileInfoHeader(info, info.Name())
-		if err != nil {
-			pw.CloseWithError(fmt.Errorf("failed to create tar file info header: %w", err))
-			return
-		}
+				// Create a relative path for the tar file header.
+				relPath, err := filepath.Rel(workDir, path)
+				if err != nil {
+					return fmt.Errorf("failed to get relative path: %w", err)
+				}
 
-		if err := tw.WriteHeader(header); err != nil {
-			pw.CloseWithError(fmt.Errorf("failed to write header to tar writer: %w", err))
-			return
-		}
+				header, err := tar.FileInfoHeader(info, "")
+				if err != nil {
+					return fmt.Errorf("failed to create tar header: %w", err)
+				}
 
-		_, err = io.Copy(tw, file)
-		if err != nil {
-			pw.CloseWithError(fmt.Errorf("failed to copy file to tar writer: %w", err))
-			return
+				// Set the header name to preserve directory structure.
+				header.Name = relPath
+				if err := tw.WriteHeader(header); err != nil {
+					return fmt.Errorf("failed to write header: %w", err)
+				}
+
+				if !info.IsDir() {
+					file, err := os.Open(path)
+					if err != nil {
+						return fmt.Errorf("failed to open file %s: %w", path, err)
+					}
+					defer file.Close()
+
+					if _, err := io.Copy(tw, file); err != nil {
+						return fmt.Errorf("failed to write file %s to tar: %w", path, err)
+					}
+				}
+
+				return nil
+			})
+
+			if err != nil {
+				pw.CloseWithError(fmt.Errorf("failed to walk directory: %w", err))
+				return
+			}
+		} else {
+			// For a single file, include the directory structure.
+			file, err := os.Open(srcPath)
+			if err != nil {
+				pw.CloseWithError(fmt.Errorf("failed to open file: %w", err))
+				return
+			}
+			defer file.Close()
+
+			header, err := tar.FileInfoHeader(info, "")
+			if err != nil {
+				pw.CloseWithError(fmt.Errorf("failed to create tar header: %w", err))
+				return
+			}
+
+			// Use relative path as the header name to preserve directory structure
+			// This keeps the directory structure as part of the file path in the tar.
+			relPath, err := filepath.Rel(workDir, srcPath)
+			if err != nil {
+				pw.CloseWithError(fmt.Errorf("failed to get relative path: %w", err))
+				return
+			}
+
+			// Use the relative path (including directories) as the header name.
+			header.Name = relPath
+			if err := tw.WriteHeader(header); err != nil {
+				pw.CloseWithError(fmt.Errorf("failed to write header: %w", err))
+				return
+			}
+
+			if _, err := io.Copy(tw, file); err != nil {
+				pw.CloseWithError(fmt.Errorf("failed to copy file to tar: %w", err))
+				return
+			}
 		}
 	}()
 
 	return pr, nil
 }
 
-// Untar untars the target stream to the destination path.
+// Untar extracts the contents of a tar archive from the provided reader
+// to the specified destination path.
 func Untar(reader io.Reader, destPath string) error {
-	// uncompress gzip if it is a .tar.gz file
-	// gzipReader, err := gzip.NewReader(reader)
-	// if err != nil {
-	//     return err
-	// }
-	// defer gzipReader.Close()
-	// tarReader := tar.NewReader(gzipReader)
-
 	tarReader := tar.NewReader(reader)
 
+	// Ensure destination directory exists.
 	if err := os.MkdirAll(destPath, 0755); err != nil {
-		return err
+		return fmt.Errorf("failed to create destination directory: %w", err)
 	}
 
 	for {
@@ -90,39 +142,74 @@ func Untar(reader io.Reader, destPath string) error {
 			break
 		}
 		if err != nil {
-			return err
+			return fmt.Errorf("error reading tar: %w", err)
 		}
 
-		// sanitize filepaths to prevent directory traversal.
+		// Sanitize file paths to prevent directory traversal.
 		cleanPath := filepath.Clean(header.Name)
-		if strings.Contains(cleanPath, "..") {
+		if strings.Contains(cleanPath, "..") || strings.HasPrefix(cleanPath, "/") || strings.HasPrefix(cleanPath, ":\\") {
 			return fmt.Errorf("tar file contains invalid path: %s", cleanPath)
 		}
 
-		path := filepath.Join(destPath, cleanPath)
-		// check the file type.
+		targetPath := filepath.Join(destPath, cleanPath)
+
+		// Create directories for all path components.
+		dirPath := filepath.Dir(targetPath)
+		if err := os.MkdirAll(dirPath, 0755); err != nil {
+			return fmt.Errorf("failed to create directory %s: %w", dirPath, err)
+		}
+
 		switch header.Typeflag {
 		case tar.TypeDir:
-			if err := os.MkdirAll(path, 0755); err != nil {
-				return err
+			if err := os.MkdirAll(targetPath, os.FileMode(header.Mode)); err != nil {
+				return fmt.Errorf("failed to create directory %s: %w", targetPath, err)
 			}
+
 		case tar.TypeReg:
-			file, err := os.Create(path)
+			file, err := os.OpenFile(
+				targetPath,
+				os.O_CREATE|os.O_RDWR|os.O_TRUNC,
+				os.FileMode(header.Mode),
+			)
 			if err != nil {
-				return err
+				return fmt.Errorf("failed to create file %s: %w", targetPath, err)
 			}
 
 			if _, err := io.Copy(file, tarReader); err != nil {
 				file.Close()
-				return err
+				return fmt.Errorf("failed to write to file %s: %w", targetPath, err)
 			}
 			file.Close()
 
-			if err := os.Chmod(path, os.FileMode(header.Mode)); err != nil {
-				return err
+		case tar.TypeSymlink:
+			if isRel(header.Linkname, destPath) && isRel(header.Name, destPath) {
+				if err := os.Symlink(header.Linkname, targetPath); err != nil {
+					return fmt.Errorf("failed to create symlink %s -> %s: %w", targetPath, header.Linkname, err)
+				}
+			} else {
+				return fmt.Errorf("symlink %s -> %s points outside of destination directory", targetPath, header.Linkname)
 			}
+
+		default:
+			// Skip other types.
+			continue
 		}
 	}
 
 	return nil
+}
+
+// isRel checks if the candidate path is within the target directory after resolving symbolic links.
+func isRel(candidate, target string) bool {
+	if filepath.IsAbs(candidate) {
+		return false
+	}
+
+	realpath, err := filepath.EvalSymlinks(filepath.Join(target, candidate))
+	if err != nil {
+		return false
+	}
+
+	relpath, err := filepath.Rel(target, realpath)
+	return err == nil && !strings.HasPrefix(filepath.Clean(relpath), "..")
 }

--- a/pkg/archiver/archiver_test.go
+++ b/pkg/archiver/archiver_test.go
@@ -1,0 +1,95 @@
+/*
+ *     Copyright 2024 The CNAI Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package archiver
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestTar(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "archiver_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	filePath := filepath.Join(tmpDir, "testfile.txt")
+	if err := os.WriteFile(filePath, []byte("hello"), 0644); err != nil {
+		t.Fatalf("write file error: %v", err)
+	}
+
+	tarReader, err := Tar(filePath, tmpDir)
+	if err != nil {
+		t.Fatalf("Tar error: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, tarReader); err != nil {
+		t.Fatalf("copy tar error: %v", err)
+	}
+
+	if buf.Len() == 0 {
+		t.Fatal("tar archive is empty")
+	}
+}
+
+func TestUntar(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "archiver_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	filePath := filepath.Join(tmpDir, "testfile.txt")
+	if err := os.WriteFile(filePath, []byte("hello"), 0644); err != nil {
+		t.Fatalf("write file error: %v", err)
+	}
+
+	tarReader, err := Tar(filePath, tmpDir)
+	if err != nil {
+		t.Fatalf("Tar error: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, tarReader); err != nil {
+		t.Fatalf("copy tar error: %v", err)
+	}
+
+	extractDir, err := os.MkdirTemp("", "archiver_extracted")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(extractDir)
+
+	if err := Untar(bytes.NewReader(buf.Bytes()), extractDir); err != nil {
+		t.Fatalf("Untar error: %v", err)
+	}
+
+	extractedFile := filepath.Join(extractDir, filepath.Base(filePath))
+	data, err := os.ReadFile(extractedFile)
+	if err != nil {
+		t.Fatalf("read extracted file error: %v", err)
+	}
+
+	if string(data) != "hello" {
+		t.Errorf("expected 'hello', got '%s'", string(data))
+	}
+}

--- a/pkg/backend/extract.go
+++ b/pkg/backend/extract.go
@@ -21,11 +21,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"path/filepath"
 
 	"github.com/CloudNativeAI/modctl/pkg/archiver"
 	"github.com/CloudNativeAI/modctl/pkg/storage"
-	modelspec "github.com/CloudNativeAI/model-spec/specs-go/v1"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
@@ -66,18 +64,12 @@ func exportModelArtifact(ctx context.Context, store storage.Storage, manifest oc
 		if err != nil {
 			return fmt.Errorf("failed to pull the blob from storage: %w", err)
 		}
+
 		defer reader.Close()
+
 		bufferedReader := bufio.NewReaderSize(reader, defaultBufferSize)
-
-		targetDir := output
-		// get the original filepath in order to restore the original repo structure.
-		originalFilePath := layer.Annotations[modelspec.AnnotationFilepath]
-		if dir := filepath.Dir(originalFilePath); dir != "" {
-			targetDir = filepath.Join(targetDir, dir)
-		}
-
 		// untar the blob to the target directory.
-		if err := archiver.Untar(bufferedReader, targetDir); err != nil {
+		if err := archiver.Untar(bufferedReader, output); err != nil {
 			return fmt.Errorf("failed to untar the blob to output directory: %w", err)
 		}
 	}


### PR DESCRIPTION
This pull request includes several improvements to the tar and untar functionality in the `archiver` package, as well as some enhancements in the backend build and extract processes. The most important changes include updating the `Tar` and `Untar` functions to handle directories and file paths more robustly, and adding file type checks in the build process.

Improvements to tar and untar functionality:

* [`pkg/archiver/archiver.go`](diffhunk://#diff-986cad88abd254d73a07b7666554aa9d84c8db3851c3084418ae24d8733c39ebL28-R127): Enhanced the `Tar` function to handle directories and preserve directory structures. Updated the `Untar` function to sanitize file paths and create necessary directories. [[1]](diffhunk://#diff-986cad88abd254d73a07b7666554aa9d84c8db3851c3084418ae24d8733c39ebL28-R127) [[2]](diffhunk://#diff-986cad88abd254d73a07b7666554aa9d84c8db3851c3084418ae24d8733c39ebL93-R182)

Backend build process enhancements:

* [`pkg/backend/build/build.go`](diffhunk://#diff-fca68706e95344e5665bfc23020fb22f71036dfd4b33800db12f962eff376643R40-R48): Added a check in the `BuildLayer` function to ensure the path is not a directory, as directories are not supported yet.

Code cleanup:

* [`pkg/backend/extract.go`](diffhunk://#diff-e1a825c6b4039fbae050899c58346ac2ad7bcd46f579e16b1b78fc5504848fddL24-L28): Removed unused imports and simplified the `exportModelArtifact` function by eliminating redundant directory structure restoration. [[1]](diffhunk://#diff-e1a825c6b4039fbae050899c58346ac2ad7bcd46f579e16b1b78fc5504848fddL24-L28) [[2]](diffhunk://#diff-e1a825c6b4039fbae050899c58346ac2ad7bcd46f579e16b1b78fc5504848fddL69-R72)