### PR TITLE
fix: add retry client for pull and push operation

### DIFF
--- a/pkg/backend/pull.go
+++ b/pkg/backend/pull.go
@@ -32,6 +32,7 @@ import (
 	"oras.land/oras-go/v2/registry/remote"
 	"oras.land/oras-go/v2/registry/remote/auth"
 	"oras.land/oras-go/v2/registry/remote/credentials"
+	"oras.land/oras-go/v2/registry/remote/retry"
 )
 
 // Pull pulls an artifact from a registry.
@@ -63,19 +64,19 @@ func (b *backend) Pull(ctx context.Context, target string, opts ...Option) error
 	}
 
 	// create the http client.
-	httpClient := http.DefaultClient
+	httpClient := &http.Client{}
 	if options.proxy != "" {
 		proxyURL, err := url.Parse(options.proxy)
 		if err != nil {
 			return fmt.Errorf("failed to parse the proxy URL: %w", err)
 		}
 
-		httpClient.Transport = &http.Transport{
+		httpClient.Transport = retry.NewTransport(&http.Transport{
 			Proxy: http.ProxyURL(proxyURL),
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: options.insecure,
 			},
-		}
+		})
 	}
 
 	src.Client = &auth.Client{

--- a/pkg/backend/push.go
+++ b/pkg/backend/push.go
@@ -31,6 +31,7 @@ import (
 	"oras.land/oras-go/v2/registry/remote"
 	"oras.land/oras-go/v2/registry/remote/auth"
 	"oras.land/oras-go/v2/registry/remote/credentials"
+	"oras.land/oras-go/v2/registry/remote/retry"
 )
 
 // Push pushes the image to the registry.
@@ -66,6 +67,7 @@ func (b *backend) Push(ctx context.Context, target string, opts ...Option) error
 	dst.Client = &auth.Client{
 		Cache:      auth.NewCache(),
 		Credential: credentials.Credential(credStore),
+		Client:     retry.DefaultClient,
 	}
 
 	if options.plainHTTP {


### PR DESCRIPTION
This pull request includes changes to the backend's pull and push functionalities to enhance the reliability of HTTP client operations by incorporating retry mechanisms. The most important changes include adding a new import for the retry package and modifying the HTTP client initialization to use the retry transport.

Closes https://github.com/CloudNativeAI/modctl/issues/101

Enhancements to HTTP client reliability:

* [`pkg/backend/pull.go`](diffhunk://#diff-f2435c0ad2b72cf7e41c9392804ffc2c7c29981c749a01127d335d228698ac00R35): Added import for `retry` package (`oras.land/oras-go/v2/registry/remote/retry`) and modified the HTTP client initialization to use `retry.NewTransport` for handling retries during pull operations. [[1]](diffhunk://#diff-f2435c0ad2b72cf7e41c9392804ffc2c7c29981c749a01127d335d228698ac00R35) [[2]](diffhunk://#diff-f2435c0ad2b72cf7e41c9392804ffc2c7c29981c749a01127d335d228698ac00L66-R79)
* [`pkg/backend/push.go`](diffhunk://#diff-9dcd5308044bc9473f04358490f28c6748ec7bcf3cfa52058ef2756fb495846fR34): Added import for `retry` package (`oras.land/oras-go/v2/registry/remote/retry`) and set the `Client` field of the `auth.Client` to `retry.DefaultClient` for handling retries during push operations. [[1]](diffhunk://#diff-9dcd5308044bc9473f04358490f28c6748ec7bcf3cfa52058ef2756fb495846fR34) [[2]](diffhunk://#diff-9dcd5308044bc9473f04358490f28c6748ec7bcf3cfa52058ef2756fb495846fR70)