### PR TITLE
fix: print the ls output to stdout

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -63,7 +63,7 @@ func runList(ctx context.Context) error {
 		return err
 	}
 
-	tw := tabwriter.NewWriter(os.Stderr, 0, 0, 4, ' ', 0)
+	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 4, ' ', 0)
 	defer tw.Flush()
 	fmt.Fprintln(tw, "REPOSITORY\tTAG\tDIGEST\tCREATED\tSIZE")
 


### PR DESCRIPTION
This pull request includes a small but important change to the `cmd/list.go` file. The change modifies the output destination for the `tabwriter` from `os.Stderr` to `os.Stdout`.

Output destination change:

* [`cmd/list.go`](diffhunk://#diff-2cb6b39b26188bd68fce779dd82957aa4b969400c8a1554746a19f388924d9e5L66-R66): Changed the `tabwriter.NewWriter` output from `os.Stderr` to `os.Stdout` to ensure the output is directed to the standard output stream instead of the standard error stream.