### PR TITLE
fix: push tag if the tag not bound to the existed manifest

### DIFF
--- a/pkg/backend/push.go
+++ b/pkg/backend/push.go
@@ -131,6 +131,18 @@ func pushIfNotExist(ctx context.Context, pb *ProgressBar, prompt string, src sto
 	}
 
 	if exist {
+		// if the descriptor is the manifest, should check the tag existence as well.
+		if desc.MediaType == ocispec.MediaTypeImageManifest {
+			_, _, err := dst.FetchReference(ctx, tag)
+			if err != nil {
+				// try to push the tag if error occurred when fetch reference.
+				if err := dst.Tag(ctx, desc, tag); err != nil {
+					pb.Abort(desc)
+					return fmt.Errorf("failed to push tag to remote: %w", err)
+				}
+			}
+		}
+
 		pb.PrintMessage(prompt, desc, "skipped: already exists")
 		return nil
 	}


### PR DESCRIPTION
This pull request includes an important change to the `pushIfNotExist` function in the `pkg/backend/push.go` file. The change ensures that when a descriptor is a manifest, the existence of the tag is also checked and handled appropriately.

Closes https://github.com/CloudNativeAI/modctl/issues/106

Key change:

* [`pkg/backend/push.go`](diffhunk://#diff-9dcd5308044bc9473f04358490f28c6748ec7bcf3cfa52058ef2756fb495846fR134-R145): Added logic to check for the existence of a tag when the descriptor is a manifest. If the tag does not exist or an error occurs while fetching the reference, the tag is pushed to the remote.