### PR TITLE
fix: fix the mismatch cmd paramter name of modelfile generate

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -48,7 +48,7 @@ func init() {
 	flags.StringVarP(&genConfig.Name, "name", "n", "", "Model name (string), such as llama3-8b-instruct, gpt2-xl, qwen2-vl-72b-instruct, etc.")
 	flags.StringVarP(&genConfig.Version, "version", "v", "", "Model version (string), such as v1, v2, etc.")
 	flags.StringVarP(&genConfig.OutputPath, "output", "o", "./", "Output path (string), such as /path/to/output.")
-	flags.BoolVar(&genConfig.IgnoreUnrecognized, "ignore_unrecognized", false, "Ignore the unrecognized file types in directory.")
+	flags.BoolVar(&genConfig.IgnoreUnrecognized, "ignore-unrecognized", false, "Ignore the unrecognized file types in directory.")
 	flags.BoolVar(&genConfig.Overwrite, "overwrite", false, "Overwrite the existing modelfile.")
 	flags.StringVar(&genConfig.Arch, "arch", "", "Model architecture (string), such as transformer, cnn, rnn, etc.")
 	flags.StringVar(&genConfig.Family, "family", "", "Model family (string), such as llama3, gpt2, qwen2, etc.")


### PR DESCRIPTION
This pull request includes a minor change to the `cmd/generate.go` file to improve the consistency of flag naming conventions.

* [`cmd/generate.go`](diffhunk://#diff-d2b0f452bba73e3d2e556bae31fdf25c9c5375685adf1617bf27ceed1c66d031L51-R51): Changed the flag `ignore_unrecognized` to `ignore-unrecognized` to maintain consistency with other flag names.