### PR TITLE
feat: update modelfile commands to uppercase format

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -39,43 +39,40 @@ Example of Modelfile:
 
 ```shell
 # Model name (string), such as llama3-8b-instruct, gpt2-xl, qwen2-vl-72b-instruct, etc.
-name gemma-2b
+NAME gemma-2b
 
 # Model architecture (string), such as transformer, cnn, rnn, etc.
-arch transformer
+ARCH transformer
 
 # Model family (string), such as llama3, gpt2, qwen2, etc.
-family gemma
+FAMILY gemma
 
 # Model format (string), such as onnx, tensorflow, pytorch, etc.
-format safetensors
+FORMAT safetensors
 
 # Number of parameters in the model (integer).
-paramsize 16
+PARAMSIZE 16
 
 # Model precision (string), such as bf16, fp16, int8, etc.
-precision bf16
+PRECISION bf16
 
 # Model quantization (string), such as awq, gptq, etc.
-quantization awq
+QUANTIZATION awq
 
 # Specify model configuration file, support glob path pattern.
-config config.json
+CONFIG config.json
 
 # Specify model configuration file, support glob path pattern.
-config generation_config.json
+CONFIG generation_config.json
 
 # Model weight, support glob path pattern.
-model *.safetensors
+MODEL *.safetensors
 
 # Specify code, support glob path pattern.
-code *.py
+CODE *.py
 
 # Specify documentation, support glob path pattern.
-doc *.md
-
-# Specify dataset, support glob path pattern.
-dataset *.csv
+DOC *.md
 ```
 
 Then run the following command to build the model artifact:

--- a/pkg/modelfile/command/command.go
+++ b/pkg/modelfile/command/command.go
@@ -22,58 +22,58 @@ const (
 	// the model to be served, such as the config.json, generation_config.json, etc.
 	// The CONFIG command can be used multiple times in a modelfile, it
 	// will be copied the config file to the artifact package as a layer.
-	CONFIG = "config"
+	CONFIG = "CONFIG"
 
 	// MODEL is the command to set the model file path. The value of this command
 	// is the glob of the model file path to match the model file name.
 	// The MODEL command can be used multiple times in a modelfile, it will scan
 	// the model file path by the glob and copy each model file to the artifact
 	// package, and each model file will be a layer.
-	MODEL = "model"
+	MODEL = "MODEL"
 
 	// CODE is the command to set the code file path. The value of this commands
 	// is the glob of the code file path to match the code file name.
 	// The CODE command can be used multiple times in a modelfile, it will scan
 	// the code file path by the glob and copy each code file to the artifact
 	// package, and each code file will be a layer.
-	CODE = "code"
+	CODE = "CODE"
 
 	// DATASET is the command to set the dataset file path. The value of this commands
 	// is the glob of the dataset file path to match the dataset file name.
 	// The DATASET command can be used multiple times in a modelfile, it will scan
 	// the dataset file path by the glob and copy each dataset file to the artifact
 	// package, and each dataset file will be a layer.
-	DATASET = "dataset"
+	DATASET = "DATASET"
 
 	// DOC is the command to set the documentation file path. The value of this commands
 	// is the glob of the documentation file path to match the documentation file name.
 	// The DOC command can be used multiple times in a modelfile, it will scan
 	// the documentation file path by the glob and copy each documentation file to the artifact
 	// package, and each documentation file will be a layer.
-	DOC = "doc"
+	DOC = "DOC"
 
 	// NAME is the command to set the model name, such as llama3-8b-instruct, gpt2-xl,
 	// qwen2-vl-72b-instruct, etc.
-	NAME = "name"
+	NAME = "NAME"
 
 	// ARCH is the command to set the architecture of the model, such as transformer,
 	// cnn, rnn, etc.
-	ARCH = "arch"
+	ARCH = "ARCH"
 
 	// FAMILY is the command to set the family of the model, such as llama3, gpt2, qwen2, etc.
-	FAMILY = "family"
+	FAMILY = "FAMILY"
 
 	// FORMAT is the command to set the format of the model, such as onnx, tensorflow, pytorch, etc.
-	FORMAT = "format"
+	FORMAT = "FORMAT"
 
 	// PARAMSIZE is the command to set the parameter size of the model.
-	PARAMSIZE = "paramsize"
+	PARAMSIZE = "PARAMSIZE"
 
 	// PRECISION is the command to set the precision of the model, such as bf16, fp16, int8, etc.
-	PRECISION = "precision"
+	PRECISION = "PRECISION"
 
 	// QUANTIZATION is the command to set the quantization of the model, such as awq, gptq, etc.
-	QUANTIZATION = "quantization"
+	QUANTIZATION = "QUANTIZATION"
 )
 
 // Commands is a list of all the commands that can be used in a modelfile.

--- a/pkg/modelfile/constants.go
+++ b/pkg/modelfile/constants.go
@@ -116,6 +116,7 @@ func isFileType(filename string, patterns []string) bool {
 			return true
 		}
 	}
+
 	return false
 }
 
@@ -135,5 +136,6 @@ func isSkippable(filename string) bool {
 			return true
 		}
 	}
+
 	return false
 }

--- a/pkg/modelfile/modelfile_test.go
+++ b/pkg/modelfile/modelfile_test.go
@@ -49,18 +49,18 @@ func TestNewModelfile(t *testing.T) {
 		{
 			input: `
 # This is a comment
-config config1
-model model1
-code code1
-dataset dataset1
-doc doc1
-name name1
-arch arch1
-family family1
-format format1
-paramsize paramsize1
-precision precision1
-quantization quantization1
+CONFIG config1
+MODEL model1
+CODE code1
+DATASET dataset1
+DOC doc1
+NAME name1
+ARCH arch1
+FAMILY family1
+FORMAT format1
+PARAMSIZE paramsize1
+PRECISION precision1
+QUANTIZATION quantization1
 `,
 			expectErr:    nil,
 			configs:      []string{"config1"},
@@ -79,18 +79,18 @@ quantization quantization1
 		{
 			input: `
 # This is a comment
-config        config1
-model         model1
-code          code1
-dataset       dataset1
-doc           doc1
-name          name1
-arch          arch1
-family        family1
-format        format1
-paramsize     paramsize1
-precision     precision1
-quantization  quantization1
+CONFIG        config1
+MODEL         model1
+CODE          code1
+DATASET       dataset1
+DOC           doc1
+NAME          name1
+ARCH          arch1
+FAMILY        family1
+FORMAT        format1
+PARAMSIZE     paramsize1
+PRECISION     precision1
+QUANTIZATION  quantization1
 `,
 			expectErr:    nil,
 			configs:      []string{"config1"},
@@ -108,23 +108,23 @@ quantization  quantization1
 		},
 		{
 			input: `
-config config1
-config config2
-model model1
-model model2
-code code1
-code code2
-dataset dataset1
-dataset dataset2
-doc doc1
-doc doc2
-name name1
-arch arch1
-family family1
-format format1
-paramsize paramsize1
-precision precision1
-quantization quantization1
+CONFIG config1
+CONFIG config2
+MODEL model1
+MODEL model2
+CODE code1
+CODE code2
+DATASET dataset1
+DATASET dataset2
+DOC doc1
+DOC doc2
+NAME name1
+ARCH arch1
+FAMILY family1
+FORMAT format1
+PARAMSIZE paramsize1
+PRECISION precision1
+QUANTIZATION quantization1
 		`,
 			expectErr:    nil,
 			configs:      []string{"config1", "config2"},
@@ -142,28 +142,28 @@ quantization quantization1
 		},
 		{
 			input: `
-config config1
-config config1
-config config2
-model model1
-model model1
-model model2
-code code1
-code code1
-code code2
-dataset dataset1
-dataset dataset1
-dataset dataset2
-doc doc1
-doc doc1
-doc doc2
-name name1
-arch arch1
-family family1
-format format1
-paramsize paramsize1
-precision precision1
-quantization quantization1
+CONFIG config1
+CONFIG config1
+CONFIG config2
+MODEL model1
+MODEL model1
+MODEL model2
+CODE code1
+CODE code1
+CODE code2
+DATASET dataset1
+DATASET dataset1
+DATASET dataset2
+DOC doc1
+DOC doc1
+DOC doc2
+NAME name1
+ARCH arch1
+FAMILY family1
+FORMAT format1
+PARAMSIZE paramsize1
+PRECISION precision1
+QUANTIZATION quantization1
 		`,
 			expectErr:    nil,
 			configs:      []string{"config1", "config2"},
@@ -181,40 +181,40 @@ quantization quantization1
 		},
 		{
 			input: `
-invalid command
+INVALID command
 		`,
-			expectErr: errors.New("parse error on line 1: invalid command"),
+			expectErr: errors.New("parse error on line 1: INVALID command"),
 		},
 		{
 			input: `
 # This is a comment
-invalid command
+INVALID command
 		`,
-			expectErr: errors.New("parse error on line 2: invalid command"),
+			expectErr: errors.New("parse error on line 2: INVALID command"),
 		},
 		{
 			input: `
 
 
 # This is a comment
-invalid command
+INVALID command
 		`,
-			expectErr: errors.New("parse error on line 4: invalid command"),
+			expectErr: errors.New("parse error on line 4: INVALID command"),
 		},
 		{
 			input: `
 # This is a comment
 
-invalid command
+INVALID command
 		`,
-			expectErr: errors.New("parse error on line 3: invalid command"),
+			expectErr: errors.New("parse error on line 3: INVALID command"),
 		},
 		{
 			input: `
 # This is a comment
-model adapter1
-name foo
-name bar
+MODEL adapter1
+NAME foo
+NAME bar
 		`,
 			expectErr: errors.New("duplicate name command on line 4"),
 		},
@@ -787,32 +787,32 @@ func TestModelfile_Content(t *testing.T) {
 			expectedParts: []string{
 				"# Generated at",
 				"# Model name",
-				"name test-model",
+				"NAME test-model",
 				"# Model architecture",
-				"arch transformer",
+				"ARCH transformer",
 				"# Model family",
-				"family llama",
+				"FAMILY llama",
 				"# Model format",
-				"format safetensors",
+				"FORMAT safetensors",
 				"# Model paramsize",
-				"paramsize 7B",
+				"PARAMSIZE 7B",
 				"# Model precision",
-				"precision float16",
+				"PRECISION float16",
 				"# Model quantization",
-				"quantization int8",
+				"QUANTIZATION int8",
 				"# Config files",
-				"config config.json",
+				"CONFIG config.json",
 				"# Documentation files",
-				"doc README.md",
+				"DOC README.md",
 				"# Code files",
-				"code convert.py",
-				"code inference.py",
+				"CODE convert.py",
+				"CODE inference.py",
 				"# Model files",
-				"model model.bin",
-				"model model.safetensors",
+				"MODEL model.bin",
+				"MODEL model.safetensors",
 			},
 			notExpectParts: []string{
-				"dataset",
+				"DATASET",
 			},
 		},
 		{
@@ -828,11 +828,11 @@ func TestModelfile_Content(t *testing.T) {
 			expectedParts: []string{
 				"# Generated at",
 				"# Model name",
-				"name minimal",
+				"NAME minimal",
 			},
 			notExpectParts: []string{
-				"arch", "family", "format", "paramsize", "precision", "quantization",
-				"config", "code", "model", "dataset", "doc",
+				"ARCH", "FAMILY", "FORMAT", "PARAMSIZE", "PRECISION", "QUANTIZATION",
+				"CONFIG", "CODE", "MODEL", "DATASET", "DOC",
 			},
 		},
 		{
@@ -854,24 +854,24 @@ func TestModelfile_Content(t *testing.T) {
 			expectedParts: []string{
 				"# Generated at",
 				"# Model name",
-				"name tiny-gpt",
+				"NAME tiny-gpt",
 				"# Model architecture",
-				"arch transformer",
+				"ARCH transformer",
 				"# Model family",
-				"family gpt2",
+				"FAMILY gpt2",
 				"# Model format",
-				"format pytorch",
+				"FORMAT pytorch",
 				"# Model paramsize",
-				"paramsize 125M",
+				"PARAMSIZE 125M",
 				"# Model precision",
-				"precision float32",
+				"PRECISION float32",
 				"# Config files",
-				"config config.json",
+				"CONFIG config.json",
 				"# Model files",
-				"model pytorch_model.bin",
+				"MODEL pytorch_model.bin",
 			},
 			notExpectParts: []string{
-				"quantization", "code", "dataset", "doc",
+				"QUANTIZATION", "CODE", "DATASET", "DOC",
 			},
 		},
 		{
@@ -893,26 +893,26 @@ func TestModelfile_Content(t *testing.T) {
 			expectedParts: []string{
 				"# Generated at",
 				"# Model name",
-				"name llama-large",
+				"NAME llama-large",
 				"# Model architecture",
-				"arch transformer",
+				"ARCH transformer",
 				"# Model family",
-				"family llama",
+				"FAMILY llama",
 				"# Model format",
-				"format safetensors",
+				"FORMAT safetensors",
 				"# Model paramsize",
-				"paramsize 13B",
+				"PARAMSIZE 13B",
 				"# Model precision",
-				"precision bfloat16",
+				"PRECISION bfloat16",
 				"# Config files",
-				"config config.json",
+				"CONFIG config.json",
 				"# Model files",
-				"model model-00001-of-00003.safetensors",
-				"model model-00002-of-00003.safetensors",
-				"model model-00003-of-00003.safetensors",
+				"MODEL model-00001-of-00003.safetensors",
+				"MODEL model-00002-of-00003.safetensors",
+				"MODEL model-00003-of-00003.safetensors",
 			},
 			notExpectParts: []string{
-				"quantization", "code", "dataset", "doc",
+				"QUANTIZATION", "CODE", "DATASET", "DOC",
 			},
 		},
 		{
@@ -933,24 +933,24 @@ func TestModelfile_Content(t *testing.T) {
 			expectedParts: []string{
 				"# Generated at",
 				"# Model name",
-				"name mistral-quantized",
+				"NAME mistral-quantized",
 				"# Model architecture",
-				"arch transformer",
+				"ARCH transformer",
 				"# Model family",
-				"family mistral",
+				"FAMILY mistral",
 				"# Model format",
-				"format gguf",
+				"FORMAT gguf",
 				"# Model paramsize",
-				"paramsize 7B",
+				"PARAMSIZE 7B",
 				"# Model quantization",
-				"quantization Q4_K_M",
+				"QUANTIZATION Q4_K_M",
 				"# Config files",
-				"config config.json",
+				"CONFIG config.json",
 				"# Model files",
-				"model model.gguf",
+				"MODEL model.gguf",
 			},
 			notExpectParts: []string{
-				"precision", "code", "dataset", "doc",
+				"PRECISION", "CODE", "DATASET", "DOC",
 			},
 		},
 		{
@@ -971,25 +971,25 @@ func TestModelfile_Content(t *testing.T) {
 			expectedParts: []string{
 				"# Generated at",
 				"# Model name",
-				"name mega-model",
+				"NAME mega-model",
 				"# Model architecture",
-				"arch moe",
+				"ARCH moe",
 				"# Model family",
-				"family mixtral",
+				"FAMILY mixtral",
 				"# Model format",
-				"format pytorch",
+				"FORMAT pytorch",
 				"# Model paramsize",
-				"paramsize 1.5T",
+				"PARAMSIZE 1.5T",
 				"# Model precision",
-				"precision float16",
+				"PRECISION float16",
 				"# Config files",
-				"config config.json",
+				"CONFIG config.json",
 				"# Model files",
-				"model shard-00001.bin",
-				"model shard-00002.bin",
+				"MODEL shard-00001.bin",
+				"MODEL shard-00002.bin",
 			},
 			notExpectParts: []string{
-				"quantization", "code", "dataset", "doc",
+				"QUANTIZATION", "CODE", "DATASET", "DOC",
 			},
 		},
 		{
@@ -1005,19 +1005,20 @@ func TestModelfile_Content(t *testing.T) {
 			expectedParts: []string{
 				"# Generated at",
 				"# Model name",
-				"name nested-paths-model",
-				"paramsize 3B",
+				"NAME nested-paths-model",
+				"# Model paramsize",
+				"PARAMSIZE 3B",
 				"# Config files",
-				"config configs/main.json",
-				"config configs/tokenizer/config.json",
+				"CONFIG configs/main.json",
+				"CONFIG configs/tokenizer/config.json",
 				"# Model files",
-				"model models/weights/pytorch_model.bin",
+				"MODEL models/weights/pytorch_model.bin",
 				"# Code files",
-				"code src/utils.py",
-				"code src/models/model.py",
+				"CODE src/utils.py",
+				"CODE src/models/model.py",
 			},
 			notExpectParts: []string{
-				"arch", "family", "format", "precision", "quantization", "dataset", "doc",
+				"ARCH", "FAMILY", "FORMAT", "PRECISION", "QUANTIZATION", "DATASET", "DOC",
 			},
 		},
 		{
@@ -1033,15 +1034,16 @@ func TestModelfile_Content(t *testing.T) {
 			expectedParts: []string{
 				"# Generated at",
 				"# Model name",
-				"name fractional-size",
-				"paramsize 2.7B",
+				"NAME fractional-size",
+				"# Model paramsize",
+				"PARAMSIZE 2.7B",
 				"# Config files",
-				"config config.json",
+				"CONFIG config.json",
 				"# Model files",
-				"model model.bin",
+				"MODEL model.bin",
 			},
 			notExpectParts: []string{
-				"arch", "family", "format", "precision", "quantization", "code", "dataset", "doc",
+				"ARCH", "FAMILY", "FORMAT", "PRECISION", "QUANTIZATION", "DATASET", "DOC", "CODE",
 			},
 		},
 		{
@@ -1062,22 +1064,22 @@ func TestModelfile_Content(t *testing.T) {
 			expectedParts: []string{
 				"# Generated at",
 				"# Model name",
-				"name metadata-only",
+				"NAME metadata-only",
 				"# Model architecture",
-				"arch transformer",
+				"ARCH transformer",
 				"# Model family",
-				"family gpt-neox",
+				"FAMILY gpt-neox",
 				"# Model format",
-				"format pytorch",
+				"FORMAT pytorch",
 				"# Model paramsize",
-				"paramsize 20B",
+				"PARAMSIZE 20B",
 				"# Model precision",
-				"precision bfloat16",
+				"PRECISION bfloat16",
 				"# Model quantization",
-				"quantization int4",
+				"QUANTIZATION int4",
 			},
 			notExpectParts: []string{
-				"code", "doc", "dataset",
+				"CODE", "CONFIG", "DOC",
 			},
 		},
 		{
@@ -1093,18 +1095,18 @@ func TestModelfile_Content(t *testing.T) {
 			expectedParts: []string{
 				"# Generated at",
 				"# Model name",
-				"name files-only",
+				"NAME files-only",
 				"# Config files",
-				"config config.json",
+				"CONFIG config.json",
 				"# Model files",
-				"model model.bin",
+				"MODEL model.bin",
 				"# Code files",
-				"code script.py",
+				"CODE script.py",
 				"# Documentation files",
-				"doc README.md",
+				"DOC README.md",
 			},
 			notExpectParts: []string{
-				"arch", "family", "format", "paramsize", "precision", "quantization", "dataset",
+				"ARCH", "FAMILY", "FORMAT", "PRECISION", "QUANTIZATION", "PARAMSIZE", "DATASET",
 			},
 		},
 		{
@@ -1120,27 +1122,27 @@ func TestModelfile_Content(t *testing.T) {
 			expectedParts: []string{
 				"# Generated at",
 				"# Model name",
-				"name multi-file",
+				"NAME multi-file",
 				"# Model paramsize",
-				"paramsize 7B",
+				"PARAMSIZE 7B",
 				"# Config files",
-				"config config1.json",
-				"config config2.json",
-				"config config3.json",
+				"CONFIG config1.json",
+				"CONFIG config2.json",
+				"CONFIG config3.json",
 				"# Model files",
-				"model model1.bin",
-				"model model2.bin",
-				"model model3.bin",
-				"model model4.bin",
+				"MODEL model1.bin",
+				"MODEL model2.bin",
+				"MODEL model3.bin",
+				"MODEL model4.bin",
 				"# Code files",
-				"code script1.py",
-				"code script2.py",
+				"CODE script1.py",
+				"CODE script2.py",
 				"# Documentation files",
-				"doc README1.md",
-				"doc README2.md",
+				"DOC README1.md",
+				"DOC README2.md",
 			},
 			notExpectParts: []string{
-				"aarch", "family", "format", "precision", "quantization", "dataset",
+				"ARCH", "FAMILY", "FORMAT", "PRECISION", "QUANTIZATION", "DATASET",
 			},
 		},
 		{
@@ -1156,21 +1158,21 @@ func TestModelfile_Content(t *testing.T) {
 			expectedParts: []string{
 				"# Generated at",
 				"# Model name",
-				"name special-chars",
+				"NAME special-chars",
 				"# Model paramsize",
-				"paramsize 1B",
+				"PARAMSIZE 1B",
 				"# Config files",
-				"config spaces.json",
-				"config weird-name!.yaml",
+				"CONFIG spaces.json",
+				"CONFIG weird-name!.yaml",
 				"# Model files",
-				"model model-v1.0_beta.bin",
+				"MODEL model-v1.0_beta.bin",
 				"# Code files",
-				"code spaces/script.py",
+				"CODE spaces/script.py",
 				"# Documentation files",
-				"doc weird-name!.md",
+				"DOC weird-name!.md",
 			},
 			notExpectParts: []string{
-				"arch", "family", "format", "precision", "quantization", "dataset",
+				"ARCH", "FAMILY", "FORMAT", "PRECISION", "QUANTIZATION", "DATASET",
 			},
 		},
 	}

--- a/pkg/modelfile/parser/parser.go
+++ b/pkg/modelfile/parser/parser.go
@@ -78,7 +78,7 @@ func isComment(line string) bool {
 
 // isCommand checks if the line is a command.
 func isCommand(line string) bool {
-	line = strings.ToLower(line)
+	line = strings.ToUpper(line)
 	for _, cmd := range command.Commands {
 		if strings.HasPrefix(line, cmd) {
 			return true
@@ -125,5 +125,5 @@ func splitCommand(line string) (string, []string, error) {
 		return "", nil, fmt.Errorf("invalid command line: %s", line)
 	}
 
-	return strings.ToLower(parts[0]), parts[1:], nil
+	return strings.ToUpper(parts[0]), parts[1:], nil
 }

--- a/pkg/modelfile/parser/parser_test.go
+++ b/pkg/modelfile/parser/parser_test.go
@@ -33,22 +33,22 @@ func TestParse(t *testing.T) {
 		{
 			input: `
 # This is a comment
-model model1
+MODEL model1
 `,
 			expectErr: false,
 		},
 		{
 			input: `
 # This is a comment
-invalid command
+INVALID command
 `,
 			expectErr: true,
 		},
 		{
 			input: `
 # This is a comment
-model model1
-name foo
+MODEL model1
+NAME foo
 `,
 			expectErr: false,
 		},
@@ -60,14 +60,14 @@ name foo
 		},
 		{
 			input: `
-model model1
+MODEL model1
 `,
 			expectErr: false,
 		},
 		{
 			input: `
 
-model model1
+MODEL model1
 `,
 			expectErr: false,
 		},
@@ -108,9 +108,9 @@ func TestIsCommand(t *testing.T) {
 		line     string
 		expected bool
 	}{
-		{"model foo", true},
 		{"MODEL foo", true},
-		{"name bar", true},
+		{"MODEL foo", true},
+		{"NAME bar", true},
 		{"unknown command", false},
 		{"  unknown command", false},
 	}
@@ -146,18 +146,18 @@ func TestParseCommandLine(t *testing.T) {
 		cmd       string
 		args      []string
 	}{
-		{"config foo", 1, 2, false, "config", []string{"foo"}},
-		{"CONFIG foo", 1, 2, false, "config", []string{"foo"}},
-		{"model foo", 1, 2, false, "model", []string{"foo"}},
-		{"code foo", 1, 2, false, "code", []string{"foo"}},
-		{"dataset foo", 1, 2, false, "dataset", []string{"foo"}},
-		{"name bar", 3, 4, false, "name", []string{"bar"}},
-		{"arch transformer", 5, 6, false, "arch", []string{"transformer"}},
-		{"family llama3", 7, 8, false, "family", []string{"llama3"}},
-		{"format onnx", 9, 10, false, "format", []string{"onnx"}},
-		{"paramsize 100", 11, 12, false, "paramsize", []string{"100"}},
-		{"precision bf16", 13, 14, false, "precision", []string{"bf16"}},
-		{"quantization awq", 15, 16, false, "quantization", []string{"awq"}},
+		{"CONFIG foo", 1, 2, false, "CONFIG", []string{"foo"}},
+		{"CONFIG foo", 1, 2, false, "CONFIG", []string{"foo"}},
+		{"MODEL foo", 1, 2, false, "MODEL", []string{"foo"}},
+		{"CODE foo", 1, 2, false, "CODE", []string{"foo"}},
+		{"DATASET foo", 1, 2, false, "DATASET", []string{"foo"}},
+		{"NAME bar", 3, 4, false, "NAME", []string{"bar"}},
+		{"ARCH transformer", 5, 6, false, "ARCH", []string{"transformer"}},
+		{"FAMILY llama3", 7, 8, false, "FAMILY", []string{"llama3"}},
+		{"FORMAT onnx", 9, 10, false, "FORMAT", []string{"onnx"}},
+		{"PARAMSIZE 100", 11, 12, false, "PARAMSIZE", []string{"100"}},
+		{"PRECISION bf16", 13, 14, false, "PRECISION", []string{"bf16"}},
+		{"QUANTIZATION awq", 15, 16, false, "QUANTIZATION", []string{"awq"}},
 		{"unknown command", 5, 6, true, "", nil},
 	}
 
@@ -194,8 +194,8 @@ func TestSplitCommand(t *testing.T) {
 		cmd       string
 		args      []string
 	}{
-		{"model foo", false, "model", []string{"foo"}},
-		{"name bar", false, "name", []string{"bar"}},
+		{"MODEL foo", false, "MODEL", []string{"foo"}},
+		{"NAME bar", false, "NAME", []string{"bar"}},
 		{"invalid", true, "", nil},
 	}
 


### PR DESCRIPTION
This pull request includes changes to standardize the command names in the modelfile by converting them to uppercase. The changes affect documentation, command definitions, and test cases.

Standardization of command names:

* [`docs/getting-started.md`](diffhunk://#diff-31bcba2ccafa41d46fbbd6d1219f7f1e3b1fb3cad9faa8e4dc521bbb579dd7b3L42-R75): Updated the example modelfile to use uppercase command names.
* [`pkg/modelfile/command/command.go`](diffhunk://#diff-2c84a72fe01ba0d404e94e754b1e918637817ea2e2da15b510f251f04bb60cd5L25-R76): Modified command definitions to use uppercase names.

Test updates:

* [`pkg/modelfile/modelfile_test.go`](diffhunk://#diff-788328f65cd934d3abdc884aa8ac1a54671828118a0210389b221dbe4301e122L52-R63): Updated test cases to reflect the changes in command names to uppercase. [[1]](diffhunk://#diff-788328f65cd934d3abdc884aa8ac1a54671828118a0210389b221dbe4301e122L52-R63) [[2]](diffhunk://#diff-788328f65cd934d3abdc884aa8ac1a54671828118a0210389b221dbe4301e122L82-R93) [[3]](diffhunk://#diff-788328f65cd934d3abdc884aa8ac1a54671828118a0210389b221dbe4301e122L111-R127) [[4]](diffhunk://#diff-788328f65cd934d3abdc884aa8ac1a54671828118a0210389b221dbe4301e122L145-R166) [[5]](diffhunk://#diff-788328f65cd934d3abdc884aa8ac1a54671828118a0210389b221dbe4301e122L184-R217) [[6]](diffhunk://#diff-788328f65cd934d3abdc884aa8ac1a54671828118a0210389b221dbe4301e122L790-R815) [[7]](diffhunk://#diff-788328f65cd934d3abdc884aa8ac1a54671828118a0210389b221dbe4301e122L831-R835) [[8]](diffhunk://#diff-788328f65cd934d3abdc884aa8ac1a54671828118a0210389b221dbe4301e122L857-R874) [[9]](diffhunk://#diff-788328f65cd934d3abdc884aa8ac1a54671828118a0210389b221dbe4301e122L896-R915) [[10]](diffhunk://#diff-788328f65cd934d3abdc884aa8ac1a54671828118a0210389b221dbe4301e122L936-R953) [[11]](diffhunk://#diff-788328f65cd934d3abdc884aa8ac1a54671828118a0210389b221dbe4301e122L974-R992) [[12]](diffhunk://#diff-788328f65cd934d3abdc884aa8ac1a54671828118a0210389b221dbe4301e122L1008-R1021) [[13]](diffhunk://#diff-788328f65cd934d3abdc884aa8ac1a54671828118a0210389b221dbe4301e122L1036-R1046) [[14]](diffhunk://#diff-788328f65cd934d3abdc884aa8ac1a54671828118a0210389b221dbe4301e122L1065-R1082) [[15]](diffhunk://#diff-788328f65cd934d3abdc884aa8ac1a54671828118a0210389b221dbe4301e122L1096-R1109) [[16]](diffhunk://#diff-788328f65cd934d3abdc884aa8ac1a54671828118a0210389b221dbe4301e122L1123-R1145) [[17]](diffhunk://#diff-788328f65cd934d3abdc884aa8ac1a54671828118a0210389b221dbe4301e122L1159-R1175)

Minor adjustments:

* [`pkg/modelfile/constants.go`](diffhunk://#diff-a8ba8d6aaf6a56e7d7e89dad45e9730d6cb83799c5b7f31d2793d8ade0d1cfa5R119): Added newlines for better readability in utility functions. [[1]](diffhunk://#diff-a8ba8d6aaf6a56e7d7e89dad45e9730d6cb83799c5b7f31d2793d8ade0d1cfa5R119) [[2]](diffhunk://#diff-a8ba8d6aaf6a56e7d7e89dad45e9730d6cb83799c5b7f31d2793d8ade0d1cfa5R139)