### PR TITLE
fix: ignore the ErrBlobUnknown during stat blob

### DIFF
--- a/pkg/storage/distribution/distribution.go
+++ b/pkg/storage/distribution/distribution.go
@@ -18,6 +18,7 @@ package distribution
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"regexp"
@@ -258,6 +259,11 @@ func (s *storage) StatBlob(ctx context.Context, repo, digest string) (bool, erro
 
 	_, err = repository.Blobs(ctx).Stat(ctx, godigest.Digest(digest))
 	if err != nil {
+		// If the blob not found, distribution will return ErrBlobUnknown.
+		if errors.Is(err, distribution.ErrBlobUnknown) {
+			return false, nil
+		}
+
 		return false, err
 	}
 


### PR DESCRIPTION
This pull request includes a couple of changes to the `pkg/storage/distribution/distribution.go` file, specifically aimed at improving error handling in the `StatBlob` function.

Improvements to error handling:

* [`pkg/storage/distribution/distribution.go`](diffhunk://#diff-68778df56737a4b452974ef6a28427d51587c4010306e3ae194ca75e9b6c9ed7R21): Added the `errors` package to handle error comparisons.
* [`pkg/storage/distribution/distribution.go`](diffhunk://#diff-68778df56737a4b452974ef6a28427d51587c4010306e3ae194ca75e9b6c9ed7R262-R266): Modified the `StatBlob` function to check if the error is `ErrBlobUnknown` and return `false, nil` if it is, improving the handling of blob not found scenarios.