### PR TITLE
feat: padding the diff_ids in the model config

### DIFF
--- a/pkg/backend/build.go
+++ b/pkg/backend/build.go
@@ -78,7 +78,7 @@ func (b *backend) Build(ctx context.Context, modelfilePath, workDir, target stri
 
 	layers = append(layers, layerDescs...)
 	// build the image config.
-	configDesc, err := builder.BuildConfig(ctx, hooks.NewHooks(
+	configDesc, err := builder.BuildConfig(ctx, layers, hooks.NewHooks(
 		hooks.WithOnStart(func(name string, size int64, reader io.Reader) io.Reader {
 			return pb.Add(internalpb.NormalizePrompt("Building config"), name, size, reader)
 		}),

--- a/test/mocks/backend/build/builder.go
+++ b/test/mocks/backend/build/builder.go
@@ -40,9 +40,9 @@ func (_m *Builder) EXPECT() *Builder_Expecter {
 	return &Builder_Expecter{mock: &_m.Mock}
 }
 
-// BuildConfig provides a mock function with given fields: ctx, _a1
-func (_m *Builder) BuildConfig(ctx context.Context, _a1 hooks.Hooks) (v1.Descriptor, error) {
-	ret := _m.Called(ctx, _a1)
+// BuildConfig provides a mock function with given fields: ctx, layers, _a2
+func (_m *Builder) BuildConfig(ctx context.Context, layers []v1.Descriptor, _a2 hooks.Hooks) (v1.Descriptor, error) {
+	ret := _m.Called(ctx, layers, _a2)
 
 	if len(ret) == 0 {
 		panic("no return value specified for BuildConfig")
@@ -50,17 +50,17 @@ func (_m *Builder) BuildConfig(ctx context.Context, _a1 hooks.Hooks) (v1.Descrip
 
 	var r0 v1.Descriptor
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, hooks.Hooks) (v1.Descriptor, error)); ok {
-		return rf(ctx, _a1)
+	if rf, ok := ret.Get(0).(func(context.Context, []v1.Descriptor, hooks.Hooks) (v1.Descriptor, error)); ok {
+		return rf(ctx, layers, _a2)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, hooks.Hooks) v1.Descriptor); ok {
-		r0 = rf(ctx, _a1)
+	if rf, ok := ret.Get(0).(func(context.Context, []v1.Descriptor, hooks.Hooks) v1.Descriptor); ok {
+		r0 = rf(ctx, layers, _a2)
 	} else {
 		r0 = ret.Get(0).(v1.Descriptor)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, hooks.Hooks) error); ok {
-		r1 = rf(ctx, _a1)
+	if rf, ok := ret.Get(1).(func(context.Context, []v1.Descriptor, hooks.Hooks) error); ok {
+		r1 = rf(ctx, layers, _a2)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -75,14 +75,15 @@ type Builder_BuildConfig_Call struct {
 
 // BuildConfig is a helper method to define mock.On call
 //   - ctx context.Context
-//   - _a1 hooks.Hooks
-func (_e *Builder_Expecter) BuildConfig(ctx interface{}, _a1 interface{}) *Builder_BuildConfig_Call {
-	return &Builder_BuildConfig_Call{Call: _e.mock.On("BuildConfig", ctx, _a1)}
+//   - layers []v1.Descriptor
+//   - _a2 hooks.Hooks
+func (_e *Builder_Expecter) BuildConfig(ctx interface{}, layers interface{}, _a2 interface{}) *Builder_BuildConfig_Call {
+	return &Builder_BuildConfig_Call{Call: _e.mock.On("BuildConfig", ctx, layers, _a2)}
 }
 
-func (_c *Builder_BuildConfig_Call) Run(run func(ctx context.Context, _a1 hooks.Hooks)) *Builder_BuildConfig_Call {
+func (_c *Builder_BuildConfig_Call) Run(run func(ctx context.Context, layers []v1.Descriptor, _a2 hooks.Hooks)) *Builder_BuildConfig_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(hooks.Hooks))
+		run(args[0].(context.Context), args[1].([]v1.Descriptor), args[2].(hooks.Hooks))
 	})
 	return _c
 }
@@ -92,7 +93,7 @@ func (_c *Builder_BuildConfig_Call) Return(_a0 v1.Descriptor, _a1 error) *Builde
 	return _c
 }
 
-func (_c *Builder_BuildConfig_Call) RunAndReturn(run func(context.Context, hooks.Hooks) (v1.Descriptor, error)) *Builder_BuildConfig_Call {
+func (_c *Builder_BuildConfig_Call) RunAndReturn(run func(context.Context, []v1.Descriptor, hooks.Hooks) (v1.Descriptor, error)) *Builder_BuildConfig_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
This pull request focuses on enhancing the `BuildConfig` function by including layers as an additional parameter. This change impacts multiple files, including the main build logic, related tests, and mock implementations.

Closes: https://github.com/CloudNativeAI/modctl/issues/51

Key changes include:

### Build Logic Enhancements:
* Modified `BuildConfig` to accept an additional `layers` parameter in `pkg/backend/build.go` and `pkg/backend/build/builder.go`. [[1]](diffhunk://#diff-d6967c304021925580fe39f08821dc9e301bcc02a119e188d723e6939f170a5cL81-R81) [[2]](diffhunk://#diff-8ffa00a0129cb498b64f761bd5c4133192873bb004e396b806ebd586ba2bb287L61-R62) [[3]](diffhunk://#diff-8ffa00a0129cb498b64f761bd5c4133192873bb004e396b806ebd586ba2bb287L151-R153)

### Configuration Updates:
* Updated `buildModelConfig` to process the `layers` parameter and include `DiffIDs` in the model configuration. [[1]](diffhunk://#diff-8ffa00a0129cb498b64f761bd5c4133192873bb004e396b806ebd586ba2bb287L192-R193) [[2]](diffhunk://#diff-8ffa00a0129cb498b64f761bd5c4133192873bb004e396b806ebd586ba2bb287R209-R216)

### Test Adjustments:
* Adjusted test cases in `pkg/backend/build/builder_test.go` to accommodate the new `layers` parameter in `BuildConfig`. [[1]](diffhunk://#diff-f52d8374baab56fbd0084244940a313fe50568c31938534a4eed5f2526a266b8R34) [[2]](diffhunk://#diff-f52d8374baab56fbd0084244940a313fe50568c31938534a4eed5f2526a266b8L162-R163) [[3]](diffhunk://#diff-f52d8374baab56fbd0084244940a313fe50568c31938534a4eed5f2526a266b8L182-R183) [[4]](diffhunk://#diff-f52d8374baab56fbd0084244940a313fe50568c31938534a4eed5f2526a266b8L242-R246) [[5]](diffhunk://#diff-f52d8374baab56fbd0084244940a313fe50568c31938534a4eed5f2526a266b8R262-R264)

### Mock Updates:
* Updated mock functions in `test/mocks/backend/build/builder.go` to reflect the additional `layers` parameter in `BuildConfig`. [[1]](diffhunk://#diff-554b2d2fb7cb06326c901da11d2ddc795d924d192b56d90a4ff761ab95756569L43-R63) [[2]](diffhunk://#diff-554b2d2fb7cb06326c901da11d2ddc795d924d192b56d90a4ff761ab95756569L78-R86) [[3]](diffhunk://#diff-554b2d2fb7cb06326c901da11d2ddc795d924d192b56d90a4ff761ab95756569L95-R96)