### PR TITLE
feat: add the codec support

### DIFF
--- a/pkg/backend/build/builder_test.go
+++ b/pkg/backend/build/builder_test.go
@@ -116,26 +116,26 @@ func (s *BuilderTestSuite) TestNewBuilder() {
 func (s *BuilderTestSuite) TestBuildLayer() {
 	s.Run("successful build layer", func() {
 		expectedDesc := ocispec.Descriptor{
-			MediaType: "test/media-type",
+			MediaType: "test/media-type.tar",
 			Digest:    "sha256:test",
 			Size:      100,
 		}
 
-		s.mockOutputStrategy.On("OutputLayer", mock.Anything, "test/media-type", s.tempDir, "test-file.txt", mock.AnythingOfType("int64"), mock.AnythingOfType("*io.PipeReader"), mock.Anything).
+		s.mockOutputStrategy.On("OutputLayer", mock.Anything, "test/media-type.tar", "test-file.txt", mock.AnythingOfType("string"), mock.AnythingOfType("int64"), mock.AnythingOfType("*io.PipeReader"), mock.Anything).
 			Return(expectedDesc, nil)
 
-		desc, err := s.builder.BuildLayer(context.Background(), "test/media-type", s.tempDir, s.tempFile, hooks.NewHooks())
+		desc, err := s.builder.BuildLayer(context.Background(), "test/media-type.tar", s.tempDir, s.tempFile, hooks.NewHooks())
 		s.NoError(err)
 		s.Equal(expectedDesc, desc)
 	})
 
 	s.Run("file not found", func() {
-		_, err := s.builder.BuildLayer(context.Background(), "test/media-type", s.tempDir, filepath.Join(s.tempDir, "non-existent.txt"), hooks.NewHooks())
+		_, err := s.builder.BuildLayer(context.Background(), "test/media-type.tar", s.tempDir, filepath.Join(s.tempDir, "non-existent.txt"), hooks.NewHooks())
 		s.Error(err)
 	})
 
 	s.Run("directory not supported", func() {
-		_, err := s.builder.BuildLayer(context.Background(), "test/media-type", s.tempDir, s.tempDir, hooks.NewHooks())
+		_, err := s.builder.BuildLayer(context.Background(), "test/media-type.tar", s.tempDir, s.tempDir, hooks.NewHooks())
 		s.Error(err)
 		s.True(strings.Contains(err.Error(), "is a directory and not supported yet"))
 	})

--- a/pkg/backend/build/local.go
+++ b/pkg/backend/build/local.go
@@ -46,7 +46,7 @@ type localOutput struct {
 }
 
 // OutputLayer outputs the layer blob to the local storage.
-func (lo *localOutput) OutputLayer(ctx context.Context, mediaType, workDir, relPath string, size int64, reader io.Reader, hooks hooks.Hooks) (ocispec.Descriptor, error) {
+func (lo *localOutput) OutputLayer(ctx context.Context, mediaType, relPath, digest string, size int64, reader io.Reader, hooks hooks.Hooks) (ocispec.Descriptor, error) {
 	reader = hooks.OnStart(relPath, size, reader)
 	digest, size, err := lo.store.PushBlob(ctx, lo.repo, reader, ocispec.Descriptor{})
 	if err != nil {

--- a/pkg/backend/build/local_test.go
+++ b/pkg/backend/build/local_test.go
@@ -72,7 +72,7 @@ func (s *LocalOutputTestSuite) TestOutputLayer() {
 		s.mockStorage.On("PushBlob", s.ctx, "test-repo", mock.Anything, ocispec.Descriptor{}).
 			Return(expectedDigest, expectedSize, nil).Once()
 
-		desc, err := s.localOutput.OutputLayer(s.ctx, "test/mediatype", "/work", "test-file.txt", expectedSize, reader, hooks.NewHooks())
+		desc, err := s.localOutput.OutputLayer(s.ctx, "test/mediatype", "test-file.txt", expectedDigest, expectedSize, reader, hooks.NewHooks())
 
 		s.NoError(err)
 		s.Equal("test/mediatype", desc.MediaType)

--- a/pkg/codec/codec.go
+++ b/pkg/codec/codec.go
@@ -1,0 +1,69 @@
+/*
+ *     Copyright 2025 The CNAI Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package codec
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+type Type = string
+
+const (
+	// Raw is the raw codec type.
+	Raw Type = "raw"
+
+	// Tar is the tar codec type.
+	Tar Type = "tar"
+)
+
+// Codec is an interface for encoding and decoding the data.
+type Codec interface {
+	// Encode encodes the target file into a reader.
+	Encode(targetFilePath, workDirPath string) (io.Reader, error)
+
+	// Decode reads the input reader and decodes the data into the output path.
+	Decode(reader io.Reader, outputDir, filePath string) error
+}
+
+func New(codecType Type) (Codec, error) {
+	switch codecType {
+	case Raw:
+		return newRaw(), nil
+	case Tar:
+		return newTar(), nil
+	default:
+		return nil, fmt.Errorf("unsupported codec type: %s", codecType)
+	}
+}
+
+// TypeFromMediaType returns the codec type from the media type,
+// return empty string if not supported.
+func TypeFromMediaType(mediaType string) Type {
+	// If the mediaType ends with ".tar", return Tar.
+	if strings.HasSuffix(mediaType, ".tar") {
+		return Tar
+	}
+
+	// If the mediaType ends with ".raw", return Raw.
+	if strings.HasSuffix(mediaType, ".raw") {
+		return Raw
+	}
+
+	return ""
+}

--- a/pkg/codec/raw.go
+++ b/pkg/codec/raw.go
@@ -1,0 +1,57 @@
+/*
+ *     Copyright 2025 The CNAI Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package codec
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// raw is a codec that for raw files.
+type raw struct{}
+
+// newRaw creates a new raw codec instance.
+func newRaw() *raw {
+	return &raw{}
+}
+
+// Encode reads the target file into a reader.
+func (r *raw) Encode(targetFilePath, workDirPath string) (io.Reader, error) {
+	return os.Open(targetFilePath)
+}
+
+// Decode reads the input reader and decodes the data into the output path.
+func (r *raw) Decode(reader io.Reader, outputDir, filePath string) error {
+	fullPath := filepath.Join(outputDir, filePath)
+	dir := filepath.Dir(fullPath)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+
+	file, err := os.Create(fullPath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	if _, err := io.Copy(file, reader); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/codec/tar.go
+++ b/pkg/codec/tar.go
@@ -1,0 +1,43 @@
+/*
+ *     Copyright 2025 The CNAI Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package codec
+
+import (
+	"io"
+
+	"github.com/CloudNativeAI/modctl/pkg/archiver"
+)
+
+// tar is a codec for tar files.
+type tar struct{}
+
+// newTar creates a new tar codec instance.
+func newTar() *tar {
+	return &tar{}
+}
+
+// Encode tars the target file into a reader.
+func (t *tar) Encode(targetFilePath, workDirPath string) (io.Reader, error) {
+	return archiver.Tar(targetFilePath, workDirPath)
+}
+
+// Decode reads the input reader and decodes the data into the output path.
+func (t *tar) Decode(reader io.Reader, outputDir, filePath string) error {
+	// As the file name has been provided in the tar header,
+	// so we do not care about the filePath.
+	return archiver.Untar(reader, outputDir)
+}


### PR DESCRIPTION
This pull request introduces significant changes to the `modctl` package, focusing on replacing the `archiver` package with a new `codec` package for encoding and decoding files. Additionally, it updates the `model-spec` dependency and refactors various functions to integrate the new codec system.

Dependency updates:

* Updated `github.com/CloudNativeAI/model-spec` from v0.0.2 to v0.0.3 in `go.mod`.

Refactoring and integration of codec package:

* Replaced `archiver` package with `codec` package in `pkg/backend/build/builder.go`. The `OutputLayer` method signature and the `BuildLayer` function were updated to use the new codec system for encoding files. [[1]](diffhunk://#diff-8ffa00a0129cb498b64f761bd5c4133192873bb004e396b806ebd586ba2bb287L29-R30) [[2]](diffhunk://#diff-8ffa00a0129cb498b64f761bd5c4133192873bb004e396b806ebd586ba2bb287L41-L45) [[3]](diffhunk://#diff-8ffa00a0129cb498b64f761bd5c4133192873bb004e396b806ebd586ba2bb287L70-R65) [[4]](diffhunk://#diff-8ffa00a0129cb498b64f761bd5c4133192873bb004e396b806ebd586ba2bb287L144-R172)
* Updated `OutputLayer` method in `pkg/backend/build/local.go` to use the new codec system.
* Updated `OutputLayer` method in `pkg/backend/build/remote.go` to use the new codec system. [[1]](diffhunk://#diff-a7407d833322bb1904e4de2f73366bb2ca3639e0aadc0193a5082b5591782362L25-L31) [[2]](diffhunk://#diff-a7407d833322bb1904e4de2f73366bb2ca3639e0aadc0193a5082b5591782362L83-L103)
* Replaced `archiver` package with `codec` package in `pkg/backend/extract.go` and refactored the `exportModelArtifact` function to use the new codec system for extracting layers. [[1]](diffhunk://#diff-e1a825c6b4039fbae050899c58346ac2ad7bcd46f579e16b1b78fc5504848fddR24-R28) [[2]](diffhunk://#diff-e1a825c6b4039fbae050899c58346ac2ad7bcd46f579e16b1b78fc5504848fddL60-R93)
* Replaced `archiver` package with `codec` package in `pkg/backend/pull.go` and updated the `pullAndExtractFromRemote` function to use the new codec system for extracting layers. [[1]](diffhunk://#diff-f2435c0ad2b72cf7e41c9392804ffc2c7c29981c749a01127d335d228698ac00L29) [[2]](diffhunk://#diff-f2435c0ad2b72cf7e41c9392804ffc2c7c29981c749a01127d335d228698ac00L222-R232)

Introduction of codec package:

* Added a new `codec` package with `Codec`, `RawCodec`, and `TarCodec` implementations for encoding and decoding files. [[1]](diffhunk://#diff-f1af839aa40e8d1553814897ef277f31f625ed6daf6e6f44bfeb950905efabb8R1-R69) [[2]](diffhunk://#diff-4c12a48b48d9d0895fa3f8e3e221061a135c8768dd5af2e8c6acf7993a26f153R1-R57) [[3]](diffhunk://#diff-0fc40236986d80922fd5e4469505149e5fad7ae67b056a5c5bd16624cb9a3724R1-R43)