### PR TITLE
feat: support nydusify for build and push

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -55,6 +55,8 @@ func init() {
 	flags.BoolVarP(&buildConfig.OutputRemote, "output-remote", "", false, "turning on this flag will output model artifact to remote registry directly")
 	flags.BoolVarP(&buildConfig.PlainHTTP, "plain-http", "", false, "turning on this flag will use plain HTTP instead of HTTPS")
 	flags.BoolVarP(&buildConfig.Insecure, "insecure", "", false, "turning on this flag will disable TLS verification")
+	flags.BoolVar(&buildConfig.Nydusify, "nydusify", false, "[EXPERIMENTAL] nydusify the model artifact")
+	flags.MarkHidden("nydusify")
 
 	if err := viper.BindPFlags(flags); err != nil {
 		panic(fmt.Errorf("bind cache list flags to viper: %w", err))
@@ -73,5 +75,16 @@ func runBuild(ctx context.Context, workDir string) error {
 	}
 
 	fmt.Printf("Successfully built model artifact: %s\n", buildConfig.Target)
+
+	// nydusify the model artifact if needed.
+	if buildConfig.Nydusify {
+		nydusName, err := b.Nydusify(ctx, buildConfig.Target)
+		if err != nil {
+			return fmt.Errorf("failed to nydusify %s: %w", buildConfig.Target, err)
+		}
+
+		fmt.Printf("Successfully nydusify model artifact: %s\n", nydusName)
+	}
+
 	return nil
 }

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -51,6 +51,8 @@ func init() {
 	flags := pushCmd.Flags()
 	flags.IntVar(&pushConfig.Concurrency, "concurrency", pushConfig.Concurrency, "specify the number of concurrent push operations")
 	flags.BoolVar(&pushConfig.PlainHTTP, "plain-http", false, "use plain HTTP instead of HTTPS")
+	flags.BoolVar(&pushConfig.Nydusify, "nydusify", false, "[EXPERIMENTAL] nydusify the model artifact")
+	flags.MarkHidden("nydusify")
 
 	if err := viper.BindPFlags(flags); err != nil {
 		panic(fmt.Errorf("bind cache push flags to viper: %w", err))
@@ -69,5 +71,16 @@ func runPush(ctx context.Context, target string) error {
 	}
 
 	fmt.Printf("Successfully pushed model artifact: %s\n", target)
+
+	// nydusify the model artifact if needed.
+	if pushConfig.Nydusify {
+		nydusName, err := b.Nydusify(ctx, target)
+		if err != nil {
+			return fmt.Errorf("failed to nydusify %s: %w", target, err)
+		}
+
+		fmt.Printf("Successfully nydusify model artifact: %s\n", nydusName)
+	}
+
 	return nil
 }

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -57,6 +57,9 @@ type Backend interface {
 
 	// Tag creates a new tag that refers to the source model artifact.
 	Tag(ctx context.Context, source, target string) error
+
+	// Nydusify converts the model artifact to nydus format.
+	Nydusify(ctx context.Context, target string) (string, error)
 }
 
 // backend is the implementation of Backend.

--- a/pkg/backend/nydusify.go
+++ b/pkg/backend/nydusify.go
@@ -1,0 +1,53 @@
+/*
+ *     Copyright 2025 The CNAI Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package backend
+
+import (
+	"context"
+	"os/exec"
+)
+
+const (
+	// nydusImageTagSuffix is the suffix for the nydus image tag.
+	nydusImageTagSuffix = "_nydus_v2"
+)
+
+// Nydusify is a function that converts a given model artifact to a nydus image.
+func (b *backend) Nydusify(ctx context.Context, source string) (string, error) {
+	target := source + nydusImageTagSuffix
+	cmd := exec.CommandContext(
+		ctx,
+		"nydusify",
+		"convert",
+		"--source-backend-type",
+		"model-artifact",
+		"--compressor",
+		"lz4_block",
+		"--fs-version",
+		"5",
+		"--source",
+		source,
+		"--target",
+		target,
+	)
+
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+
+	return target, nil
+}

--- a/pkg/config/build.go
+++ b/pkg/config/build.go
@@ -30,6 +30,7 @@ type Build struct {
 	OutputRemote bool
 	PlainHTTP    bool
 	Insecure     bool
+	Nydusify     bool
 }
 
 func NewBuild() *Build {
@@ -40,6 +41,7 @@ func NewBuild() *Build {
 		OutputRemote: false,
 		PlainHTTP:    false,
 		Insecure:     false,
+		Nydusify:     false,
 	}
 }
 
@@ -54,6 +56,12 @@ func (b *Build) Validate() error {
 
 	if len(b.Modelfile) == 0 {
 		return fmt.Errorf("model file path is required")
+	}
+
+	if b.Nydusify {
+		if !b.OutputRemote {
+			return fmt.Errorf("nydusify only works with output remote")
+		}
 	}
 
 	return nil

--- a/pkg/config/push.go
+++ b/pkg/config/push.go
@@ -26,12 +26,14 @@ const (
 type Push struct {
 	Concurrency int
 	PlainHTTP   bool
+	Nydusify    bool
 }
 
 func NewPush() *Push {
 	return &Push{
 		Concurrency: defaultPushConcurrency,
 		PlainHTTP:   false,
+		Nydusify:    false,
 	}
 }
 

--- a/test/mocks/backend/backend.go
+++ b/test/mocks/backend/backend.go
@@ -352,6 +352,63 @@ func (_c *Backend_Logout_Call) RunAndReturn(run func(context.Context, string) er
 	return _c
 }
 
+// Nydusify provides a mock function with given fields: ctx, target
+func (_m *Backend) Nydusify(ctx context.Context, target string) (string, error) {
+	ret := _m.Called(ctx, target)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Nydusify")
+	}
+
+	var r0 string
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (string, error)); ok {
+		return rf(ctx, target)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) string); ok {
+		r0 = rf(ctx, target)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, target)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// Backend_Nydusify_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Nydusify'
+type Backend_Nydusify_Call struct {
+	*mock.Call
+}
+
+// Nydusify is a helper method to define mock.On call
+//   - ctx context.Context
+//   - target string
+func (_e *Backend_Expecter) Nydusify(ctx interface{}, target interface{}) *Backend_Nydusify_Call {
+	return &Backend_Nydusify_Call{Call: _e.mock.On("Nydusify", ctx, target)}
+}
+
+func (_c *Backend_Nydusify_Call) Run(run func(ctx context.Context, target string)) *Backend_Nydusify_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *Backend_Nydusify_Call) Return(_a0 string, _a1 error) *Backend_Nydusify_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *Backend_Nydusify_Call) RunAndReturn(run func(context.Context, string) (string, error)) *Backend_Nydusify_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Prune provides a mock function with given fields: ctx, dryRun, removeUntagged
 func (_m *Backend) Prune(ctx context.Context, dryRun bool, removeUntagged bool) error {
 	ret := _m.Called(ctx, dryRun, removeUntagged)


### PR DESCRIPTION
This pull request introduces an experimental feature to "nydusify" model artifacts in both the build and push processes. The changes include updates to the configurations, command-line flags, and the implementation of the `Nydusify` function.

### New Feature: Nydusify Model Artifacts

* Added a new `Nydusify` flag to the build and push configurations in `pkg/config/build.go` and `pkg/config/push.go` respectively. This flag is used to determine whether to nydusify the model artifact. [[1]](diffhunk://#diff-4fe11c9ce5925fd1222a68db9e81677689727dcf5e2ea068f7e2407671752adfR33) [[2]](diffhunk://#diff-7bc49abf8a6d1070cf8e9b2a0c971a719626d67c9ad709ea95bd432eddaa5644R29-R36)
* Updated the `init` functions in `cmd/build.go` and `cmd/push.go` to include the new `Nydusify` flag and mark it as hidden. [[1]](diffhunk://#diff-5794c40aa4c9301aaf9c39eacf7d3c8511f2511cb24bdd95e0a08704ba583a5fR58-R59) [[2]](diffhunk://#diff-e8011aeef8362327cdc0e4492778f39d0eb835e4cafe821111e3446637cc862eR54-R55)
* Implemented the `Nydusify` function in `pkg/backend/nydusify.go`, which converts a given image to a Nydus image using the `nydusify` command.

### Build and Push Process Updates

* Modified the `Build` and `Push` methods in `pkg/backend/build.go` and `pkg/backend/push.go` to call the `Nydusify` function if the `Nydusify` flag is set. [[1]](diffhunk://#diff-d6967c304021925580fe39f08821dc9e301bcc02a119e188d723e6939f170a5cR112-R118) [[2]](diffhunk://#diff-9dcd5308044bc9473f04358490f28c6748ec7bcf3cfa52058ef2756fb495846fR121-R127)
* Added validation to ensure that the `Nydusify` flag can only be used when the `OutputRemote` flag is also set in the build configuration.