### PR TITLE
chore: update the .goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -51,7 +51,7 @@ nfpms:
     description: A command line tool for managing artifact bundled based on the Model Format Specification
     license: "Apache 2.0"
     bindir: /usr/bin
-    builds:
+    ids:
       - modctl
     formats:
       - rpm


### PR DESCRIPTION
This pull request includes a change to the `.goreleaser.yml` file to update the configuration for the `nfpms` section.

Configuration update:

* [`.goreleaser.yml`](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689L54-R54): Changed the `builds` key to `ids` in the `nfpms` section to correct the configuration.