### PR TITLE
feat: introduce fetch command to get partial files

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,6 @@
 run:
-  deadline: 3m
+  timeout: 3m
   modules-download-mode: readonly
-  skip-dirs:
-    - test/mocks
 
 linters-settings:
   gocyclo:
@@ -11,6 +9,7 @@ linters-settings:
     sections:
       - standard
       - default
+      - prefix(github.com/CloudNativeAI/modctl)
 
 issues:
   new: true
@@ -18,6 +17,8 @@ issues:
     - linters:
         - staticcheck
       text: "SA1019:"
+  exclude-dirs:
+    - test/mocks
 
 linters:
   disable-all: true
@@ -34,6 +35,7 @@ linters:
     - errcheck
 
 output:
-  format: colored-line-number
+  formats:
+    - format: colored-line-number
   print-issued-lines: true
   print-linter-name: true

--- a/cmd/fetch.go
+++ b/cmd/fetch.go
@@ -1,0 +1,81 @@
+/*
+ *     Copyright 2025 The CNAI Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/CloudNativeAI/modctl/pkg/backend"
+	"github.com/CloudNativeAI/modctl/pkg/config"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var fetchConfig = config.NewFetch()
+
+// fetchCmd represents the modctl command for fetch.
+var fetchCmd = &cobra.Command{
+	Use:                "fetch [flags] <target>",
+	Short:              "A command line tool for modctl fetch, please note that this command is designed for remote model fetching only.",
+	Args:               cobra.ExactArgs(1),
+	DisableAutoGenTag:  true,
+	SilenceUsage:       true,
+	FParseErrWhitelist: cobra.FParseErrWhitelist{UnknownFlags: true},
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := fetchConfig.Validate(); err != nil {
+			return err
+		}
+
+		return runFetch(context.Background(), args[0])
+	},
+}
+
+// init initializes fetch command.
+func init() {
+	flags := fetchCmd.Flags()
+	flags.IntVar(&fetchConfig.Concurrency, "concurrency", fetchConfig.Concurrency, "specify the number of concurrent fetch operations")
+	flags.BoolVar(&fetchConfig.PlainHTTP, "plain-http", false, "use plain HTTP instead of HTTPS")
+	flags.BoolVar(&fetchConfig.Insecure, "insecure", false, "use insecure connection for the fetch operation and skip TLS verification")
+	flags.StringVar(&fetchConfig.Proxy, "proxy", "", "use proxy for the fetch operation")
+	flags.StringVar(&fetchConfig.Output, "output", "", "specify the directory for fetching the model artifact")
+	flags.StringSliceVar(&fetchConfig.Patterns, "patterns", []string{}, "specify the patterns for fetching the model artifact")
+
+	if err := viper.BindPFlags(flags); err != nil {
+		panic(fmt.Errorf("bind cache pull flags to viper: %w", err))
+	}
+}
+
+// runFetch runs the fetch modctl.
+func runFetch(ctx context.Context, target string) error {
+	b, err := backend.New(rootConfig.StoargeDir)
+	if err != nil {
+		return err
+	}
+
+	if target == "" {
+		return fmt.Errorf("target is required")
+	}
+
+	if err := b.Fetch(ctx, target, fetchConfig); err != nil {
+		return err
+	}
+
+	fmt.Printf("Successfully fetched model artifact: %s\n", target)
+	return nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -85,5 +85,6 @@ func init() {
 	rootCmd.AddCommand(inspectCmd)
 	rootCmd.AddCommand(extractCmd)
 	rootCmd.AddCommand(tagCmd)
+	rootCmd.AddCommand(fetchCmd)
 	rootCmd.AddCommand(modelfile.RootCmd)
 }

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -37,6 +37,9 @@ type Backend interface {
 	// Pull pulls an artifact from a registry.
 	Pull(ctx context.Context, target string, cfg *config.Pull) error
 
+	// Fetch fetches partial files to the output.
+	Fetch(ctx context.Context, target string, cfg *config.Fetch) error
+
 	// Push pushes the image to the registry.
 	Push(ctx context.Context, target string, cfg *config.Push) error
 

--- a/pkg/backend/fetch.go
+++ b/pkg/backend/fetch.go
@@ -1,0 +1,135 @@
+/*
+ *     Copyright 2025 The CNAI Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package backend
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"path/filepath"
+
+	modelspec "github.com/CloudNativeAI/model-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"golang.org/x/sync/errgroup"
+	"oras.land/oras-go/v2/registry/remote"
+	"oras.land/oras-go/v2/registry/remote/auth"
+	"oras.land/oras-go/v2/registry/remote/credentials"
+	"oras.land/oras-go/v2/registry/remote/retry"
+
+	internalpb "github.com/CloudNativeAI/modctl/internal/pb"
+	"github.com/CloudNativeAI/modctl/pkg/config"
+)
+
+// Fetch fetches partial files to the output.
+func (b *backend) Fetch(ctx context.Context, target string, cfg *config.Fetch) error {
+	// parse the repository and tag from the target.
+	ref, err := ParseReference(target)
+	if err != nil {
+		return fmt.Errorf("failed to parse the target: %w", err)
+	}
+
+	_, tag := ref.Repository(), ref.Tag()
+
+	// create the src storage from the remote repository.
+	src, err := remote.NewRepository(target)
+	if err != nil {
+		return fmt.Errorf("failed to create remote repository: %w", err)
+	}
+
+	// gets the credentials store.
+	credStore, err := credentials.NewStoreFromDocker(credentials.StoreOptions{AllowPlaintextPut: true})
+	if err != nil {
+		return fmt.Errorf("failed to create credential store: %w", err)
+	}
+
+	// create the http client.
+	httpClient := &http.Client{}
+	if cfg.Proxy != "" {
+		proxyURL, err := url.Parse(cfg.Proxy)
+		if err != nil {
+			return fmt.Errorf("failed to parse the proxy URL: %w", err)
+		}
+
+		httpClient.Transport = retry.NewTransport(&http.Transport{
+			Proxy: http.ProxyURL(proxyURL),
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: cfg.Insecure,
+			},
+		})
+	}
+
+	src.Client = &auth.Client{
+		Cache:      auth.NewCache(),
+		Credential: credentials.Credential(credStore),
+		Client:     httpClient,
+	}
+
+	if cfg.PlainHTTP {
+		src.PlainHTTP = true
+	}
+
+	_, manifestReader, err := src.Manifests().FetchReference(ctx, tag)
+	if err != nil {
+		return fmt.Errorf("failed to fetch the manifest: %w", err)
+	}
+
+	defer manifestReader.Close()
+
+	var manifest ocispec.Manifest
+	if err := json.NewDecoder(manifestReader).Decode(&manifest); err != nil {
+		return fmt.Errorf("failed to decode the manifest: %w", err)
+	}
+
+	layers := []ocispec.Descriptor{}
+	// filter the layers by patterns.
+	for _, layer := range manifest.Layers {
+		for _, pattern := range cfg.Patterns {
+			if anno := layer.Annotations; anno != nil {
+				matched, err := filepath.Match(pattern, anno[modelspec.AnnotationFilepath])
+				if err != nil {
+					return fmt.Errorf("failed to match pattern: %w", err)
+				}
+
+				if matched {
+					layers = append(layers, layer)
+				}
+			}
+		}
+	}
+
+	if len(layers) == 0 {
+		return fmt.Errorf("no layers matched the patterns")
+	}
+
+	pb := internalpb.NewProgressBar()
+	pb.Start()
+	defer pb.Stop()
+
+	g := &errgroup.Group{}
+	g.SetLimit(cfg.Concurrency)
+
+	for _, layer := range layers {
+		g.Go(func() error {
+			return pullAndExtractFromRemote(ctx, pb, internalpb.NormalizePrompt("Fetching blob"), src, cfg.Output, layer)
+		})
+	}
+
+	return g.Wait()
+}

--- a/pkg/backend/fetch_test.go
+++ b/pkg/backend/fetch_test.go
@@ -1,0 +1,152 @@
+/*
+ *     Copyright 2025 The CNAI Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package backend
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	modelspec "github.com/CloudNativeAI/model-spec/specs-go/v1"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/CloudNativeAI/modctl/pkg/config"
+)
+
+func TestFetch(t *testing.T) {
+	// Setup temporary directory for output
+	tempDir, err := os.MkdirTemp("", "fetch-test")
+	require.NoError(t, err)
+	defer os.RemoveAll(tempDir)
+
+	// Setup mock server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v2/":
+			// Registry API check
+			w.WriteHeader(http.StatusOK)
+		case "/v2/test/model/manifests/latest":
+			// Return a manifest
+			manifest := ocispec.Manifest{
+				Layers: []ocispec.Descriptor{
+					{
+						MediaType: "application/octet-stream.raw",
+						Digest:    "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+						Size:      0,
+						Annotations: map[string]string{
+							modelspec.AnnotationFilepath: "file1.txt",
+						},
+					},
+					{
+						MediaType: "application/octet-stream.raw",
+						Digest:    "sha256:a3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+						Size:      0,
+						Annotations: map[string]string{
+							modelspec.AnnotationFilepath: "file2.txt",
+						},
+					},
+				},
+			}
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(manifest))
+		case "/v2/test/model/blobs/sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			"/v2/test/model/blobs/sha256:a3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855":
+			// Return empty content for blobs
+			w.WriteHeader(http.StatusOK)
+		default:
+			t.Logf("Unexpected request to %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	// Create backend instance
+	b := &backend{}
+
+	url := strings.TrimPrefix(server.URL, "http://")
+
+	// Setup test cases
+	tests := []struct {
+		name        string
+		target      string
+		cfg         *config.Fetch
+		expectError bool
+	}{
+		{
+			name:   "fetch with pattern matching file1",
+			target: url + "/test/model:latest",
+			cfg: &config.Fetch{
+				Output:      tempDir,
+				Patterns:    []string{"file1.txt"},
+				PlainHTTP:   true,
+				Concurrency: 2,
+			},
+			expectError: false,
+		},
+		{
+			name:   "fetch with pattern matching both files",
+			target: url + "/test/model:latest",
+			cfg: &config.Fetch{
+				Output:      tempDir,
+				Patterns:    []string{"file*.txt"},
+				PlainHTTP:   true,
+				Concurrency: 2,
+			},
+			expectError: false,
+		},
+		{
+			name:   "fetch with non-matching pattern",
+			target: url + "/test/model:latest",
+			cfg: &config.Fetch{
+				Output:      tempDir,
+				Patterns:    []string{"nonexistent.txt"},
+				PlainHTTP:   true,
+				Concurrency: 2,
+			},
+			expectError: true,
+		},
+		{
+			name:   "fetch with invalid reference",
+			target: "invalid-reference",
+			cfg: &config.Fetch{
+				Output:      tempDir,
+				Patterns:    []string{"file1.txt"},
+				PlainHTTP:   true,
+				Concurrency: 2,
+			},
+			expectError: true,
+		},
+	}
+
+	// Run tests
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := b.Fetch(context.Background(), tt.target, tt.cfg)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/config/fetch.go
+++ b/pkg/config/fetch.go
@@ -1,0 +1,60 @@
+/*
+ *     Copyright 2025 The CNAI Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import "fmt"
+
+const (
+	// defaultFetchConcurrency is the default number of concurrent fetch operations.
+	defaultFetchConcurrency = 5
+)
+
+type Fetch struct {
+	Concurrency int
+	PlainHTTP   bool
+	Proxy       string
+	Insecure    bool
+	Output      string
+	Patterns    []string
+}
+
+func NewFetch() *Fetch {
+	return &Fetch{
+		Concurrency: defaultFetchConcurrency,
+		PlainHTTP:   false,
+		Proxy:       "",
+		Insecure:    false,
+		Output:      "",
+		Patterns:    []string{},
+	}
+}
+
+func (f *Fetch) Validate() error {
+	if f.Concurrency < 1 {
+		return fmt.Errorf("invalid concurrency: %d", f.Concurrency)
+	}
+
+	if f.Output == "" {
+		return fmt.Errorf("output is required")
+	}
+
+	if len(f.Patterns) == 0 {
+		return fmt.Errorf("patterns are required")
+	}
+
+	return nil
+}


### PR DESCRIPTION
This pull request introduces a new `fetch` command to the `modctl` command-line tool, allowing users to fetch partial files from a remote repository. The most important changes include adding the `fetch` command implementation, updating the backend interface, and configuring the fetch operation.

### New `fetch` command implementation:

* [`cmd/fetch.go`](diffhunk://#diff-1c38a74bd5b7032447686cc0bfafef491323991913a6d4e5aaf95e02f10c246cR1-R81): Added a new `fetch` command with various flags for configuration, including concurrency, plain HTTP, insecure connection, proxy, output directory, and patterns. The command validates the configuration and runs the fetch operation.
* [`cmd/root.go`](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR88): Registered the new `fetch` command with the root command.

### Backend updates:

* [`pkg/backend/backend.go`](diffhunk://#diff-c65bcfe9bb457434c3e69ba3f0576d7669935f350d24e2c2c58b05b4f9c510b2R40-R42): Added a `Fetch` method to the `Backend` interface to support fetching partial files.
* [`pkg/backend/fetch.go`](diffhunk://#diff-7beefd1a4433544c6caa2cc7628ef65ced67356c1167954b1d93d32be2d234a3R1-R135): Implemented the `Fetch` method, which handles the fetching of partial files based on specified patterns, using a remote repository and supporting various configurations such as proxy and concurrency.

### Configuration and testing:

* [`pkg/config/fetch.go`](diffhunk://#diff-a40c09eecad3891d7fb8b13367116ce9beb20cb180a6d683a27e48d1e03c2b8aR1-R60): Added a new `Fetch` configuration struct with validation methods and default values.
* [`pkg/backend/fetch_test.go`](diffhunk://#diff-3e4c3e0c6c9f2ac753846feaeba002fbf9b6a446dfc5f74bf05d60f705d74c5cR1-R152): Added tests for the `Fetch` method to ensure it correctly handles various scenarios, including pattern matching and invalid references.

### Linter configuration:

* [`.golangci.yml`](diffhunk://#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9L2-L5): Updated the linter configuration to include a new prefix for the `github.com/CloudNativeAI/modctl` package and excluded the `test/mocks` directory from linting. [[1]](diffhunk://#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9L2-L5) [[2]](diffhunk://#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9R12-R21)
* [`.golangci.yml`](diffhunk://#diff-6179837f7df53a6f05c522b6b7bb566d484d5465d9894fb04910dd08bb40dcc9L37-R39): Modified the output format configuration to support multiple formats.