### PR TITLE
fix: cleanup the purge uploads as well when running the prune command

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,8 @@
 run:
   timeout: 3m
   modules-download-mode: readonly
+  skip-dirs:
+    - test/mocks
 
 linters-settings:
   gocyclo:
@@ -17,8 +19,6 @@ issues:
     - linters:
         - staticcheck
       text: "SA1019:"
-  exclude-dirs:
-    - test/mocks
 
 linters:
   disable-all: true

--- a/pkg/backend/prune.go
+++ b/pkg/backend/prune.go
@@ -18,9 +18,18 @@ package backend
 
 import (
 	"context"
+	"fmt"
 )
 
 // Prune prunes the unused blobs and clean up the storage.
 func (b *backend) Prune(ctx context.Context, dryRun, removeUntagged bool) error {
-	return b.store.PerformGC(ctx, dryRun, removeUntagged)
+	if err := b.store.PerformGC(ctx, dryRun, removeUntagged); err != nil {
+		return fmt.Errorf("faile to perform gc: %w", err)
+	}
+
+	if err := b.store.PerformPurgeUploads(ctx, dryRun); err != nil {
+		return fmt.Errorf("failed to perform purge uploads: %w", err)
+	}
+
+	return nil
 }

--- a/pkg/storage/distribution/distribution.go
+++ b/pkg/storage/distribution/distribution.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"regexp"
+	"time"
 
 	distribution "github.com/distribution/distribution/v3"
 	registry "github.com/distribution/distribution/v3/registry/storage"
@@ -314,4 +315,10 @@ func (s *storage) PerformGC(ctx context.Context, dryRun, removeUntagged bool) er
 		DryRun:         dryRun,
 		RemoveUntagged: removeUntagged,
 	})
+}
+
+// PerformPurgeUploads performs the purge uploads in the storage to free up the space.
+func (s *storage) PerformPurgeUploads(ctx context.Context, dryRun bool) error {
+	_, errs := registry.PurgeUploads(ctx, s.driver, time.Now(), !dryRun)
+	return errors.Join(errs...)
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -56,6 +56,8 @@ type Storage interface {
 	ListTags(ctx context.Context, repo string) ([]string, error)
 	// PerformGC performs the garbage collection in the storage to free up the space.
 	PerformGC(ctx context.Context, dryRun, removeUntagged bool) error
+	// PerformPurgeUploads performs the purge uploads in the storage to free up the space.
+	PerformPurgeUploads(ctx context.Context, dryRun bool) error
 }
 
 // WithRootDir sets the root directory of the storage.

--- a/test/mocks/backend/backend.go
+++ b/test/mocks/backend/backend.go
@@ -138,6 +138,54 @@ func (_c *Backend_Extract_Call) RunAndReturn(run func(context.Context, string, *
 	return _c
 }
 
+// Fetch provides a mock function with given fields: ctx, target, cfg
+func (_m *Backend) Fetch(ctx context.Context, target string, cfg *config.Fetch) error {
+	ret := _m.Called(ctx, target, cfg)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Fetch")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, *config.Fetch) error); ok {
+		r0 = rf(ctx, target, cfg)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// Backend_Fetch_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Fetch'
+type Backend_Fetch_Call struct {
+	*mock.Call
+}
+
+// Fetch is a helper method to define mock.On call
+//   - ctx context.Context
+//   - target string
+//   - cfg *config.Fetch
+func (_e *Backend_Expecter) Fetch(ctx interface{}, target interface{}, cfg interface{}) *Backend_Fetch_Call {
+	return &Backend_Fetch_Call{Call: _e.mock.On("Fetch", ctx, target, cfg)}
+}
+
+func (_c *Backend_Fetch_Call) Run(run func(ctx context.Context, target string, cfg *config.Fetch)) *Backend_Fetch_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(*config.Fetch))
+	})
+	return _c
+}
+
+func (_c *Backend_Fetch_Call) Return(_a0 error) *Backend_Fetch_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Backend_Fetch_Call) RunAndReturn(run func(context.Context, string, *config.Fetch) error) *Backend_Fetch_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Inspect provides a mock function with given fields: ctx, target
 func (_m *Backend) Inspect(ctx context.Context, target string) (*backend.InspectedModelArtifact, error) {
 	ret := _m.Called(ctx, target)

--- a/test/mocks/storage/storage.go
+++ b/test/mocks/storage/storage.go
@@ -302,6 +302,53 @@ func (_c *Storage_PerformGC_Call) RunAndReturn(run func(context.Context, bool, b
 	return _c
 }
 
+// PerformPurgeUploads provides a mock function with given fields: ctx, dryRun
+func (_m *Storage) PerformPurgeUploads(ctx context.Context, dryRun bool) error {
+	ret := _m.Called(ctx, dryRun)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PerformPurgeUploads")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, bool) error); ok {
+		r0 = rf(ctx, dryRun)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// Storage_PerformPurgeUploads_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PerformPurgeUploads'
+type Storage_PerformPurgeUploads_Call struct {
+	*mock.Call
+}
+
+// PerformPurgeUploads is a helper method to define mock.On call
+//   - ctx context.Context
+//   - dryRun bool
+func (_e *Storage_Expecter) PerformPurgeUploads(ctx interface{}, dryRun interface{}) *Storage_PerformPurgeUploads_Call {
+	return &Storage_PerformPurgeUploads_Call{Call: _e.mock.On("PerformPurgeUploads", ctx, dryRun)}
+}
+
+func (_c *Storage_PerformPurgeUploads_Call) Run(run func(ctx context.Context, dryRun bool)) *Storage_PerformPurgeUploads_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(bool))
+	})
+	return _c
+}
+
+func (_c *Storage_PerformPurgeUploads_Call) Return(_a0 error) *Storage_PerformPurgeUploads_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *Storage_PerformPurgeUploads_Call) RunAndReturn(run func(context.Context, bool) error) *Storage_PerformPurgeUploads_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // PullBlob provides a mock function with given fields: ctx, repo, digest
 func (_m *Storage) PullBlob(ctx context.Context, repo string, digest string) (io.ReadCloser, error) {
 	ret := _m.Called(ctx, repo, digest)


### PR DESCRIPTION
This pull request introduces several changes to the backend and storage packages, primarily focusing on adding a new method for purging uploads and updating the mock functions accordingly. The most important changes include adding the `PerformPurgeUploads` method to the storage interface, updating the backend to call this new method, and adding mock functions for testing.

### Backend and Storage Enhancements:
* [`pkg/backend/prune.go`](diffhunk://#diff-229183f255a5cb483afc1aaf14ab93924a43682fc42c88057c9911ebfb07caabR21-R34): Updated the `Prune` method to call the new `PerformPurgeUploads` method and handle errors appropriately.
* [`pkg/storage/distribution/distribution.go`](diffhunk://#diff-68778df56737a4b452974ef6a28427d51587c4010306e3ae194ca75e9b6c9ed7R319-R324): Added the `PerformPurgeUploads` method to perform purge uploads in the storage.
* [`pkg/storage/storage.go`](diffhunk://#diff-8b98b331c5d4acbeb7274c68973d20900daaed47c8d8f3e62ba39284379166bbR59-R60): Added the `PerformPurgeUploads` method to the `Storage` interface.

### Mock Function Updates:
* [`test/mocks/backend/backend.go`](diffhunk://#diff-efcf94e58b22fbea7475d7d5035ae222d37909c3bdb960f1268f3ae204072828R141-R188): Added mock functions for the `Fetch` method, including the `Backend_Fetch_Call` struct and helper methods.
* [`test/mocks/storage/storage.go`](diffhunk://#diff-6306c8c3c7ba06fdd30b1121dcd64a479254a7589682250618f0364078e4663bR305-R351): Added mock functions for the `PerformPurgeUploads` method, including the `Storage_PerformPurgeUploads_Call` struct and helper methods.