### PR TITLE
feat: add --insecure for login command to skip tls verify

### DIFF
--- a/cmd/login.go
+++ b/cmd/login.go
@@ -63,6 +63,7 @@ func init() {
 	flags.StringVarP(&loginConfig.Password, "password", "p", "", "Password for login")
 	flags.BoolVar(&loginConfig.PasswordStdin, "password-stdin", true, "Take the password from stdin by default")
 	flags.BoolVar(&loginConfig.PlainHTTP, "plain-http", false, "Allow http connections to registry")
+	flags.BoolVar(&loginConfig.Insecure, "insecure", false, "Allow insecure connections to registry")
 
 	if err := viper.BindPFlags(flags); err != nil {
 		panic(fmt.Errorf("bind cache login flags to viper: %w", err))

--- a/pkg/config/login.go
+++ b/pkg/config/login.go
@@ -23,6 +23,7 @@ type Login struct {
 	Password      string
 	PasswordStdin bool
 	PlainHTTP     bool
+	Insecure      bool
 }
 
 func NewLogin() *Login {
@@ -31,6 +32,7 @@ func NewLogin() *Login {
 		Password:      "",
 		PasswordStdin: true,
 		PlainHTTP:     false,
+		Insecure:      false,
 	}
 }
 


### PR DESCRIPTION
This pull request introduces support for insecure connections to the registry by adding a new `Insecure` flag and updating the relevant code to handle this new option. The most important changes include modifications to the command-line interface, backend login logic, and configuration structure.

### Command-line Interface Updates:
* Added a new `--insecure` flag to the `login` command to allow insecure connections to the registry (`cmd/login.go`).

### Backend Login Logic:
* Imported necessary packages for handling HTTP and TLS configurations (`pkg/backend/login.go`).
* Updated the `Login` function to configure the HTTP client with the `InsecureSkipVerify` option based on the new `Insecure` flag (`pkg/backend/login.go`).

### Configuration Structure:
* Added an `Insecure` boolean field to the `Login` struct to store the insecure connection option (`pkg/config/login.go`).
* Initialized the `Insecure` field in the `NewLogin` function to its default value (`pkg/config/login.go`).