### PR TITLE
feat: store the modelfile to the manifest annotation

### DIFF
--- a/pkg/backend/attach.go
+++ b/pkg/backend/attach.go
@@ -150,7 +150,7 @@ func (b *backend) Attach(ctx context.Context, filepath string, cfg *config.Attac
 	}
 
 	// Build the model manifest.
-	_, err = builder.BuildManifest(ctx, layers, configDesc, manifestAnnotation(), hooks.NewHooks(
+	_, err = builder.BuildManifest(ctx, layers, configDesc, srcManifest.Annotations, hooks.NewHooks(
 		hooks.WithOnStart(func(name string, size int64, reader io.Reader) io.Reader {
 			return pb.Add(internalpb.NormalizePrompt("Building manifest"), name, size, reader)
 		}),

--- a/pkg/backend/build.go
+++ b/pkg/backend/build.go
@@ -34,6 +34,11 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
+const (
+	// annotationModelfile is the annotation key for the Modelfile.
+	annotationModelfile = "org.cnai.modctl.modelfile"
+)
+
 // Build builds the user materials into the model artifact which follows the Model Spec.
 func (b *backend) Build(ctx context.Context, modelfilePath, workDir, target string, cfg *config.Build) error {
 	// parse the repo name and tag name from target.
@@ -105,7 +110,7 @@ func (b *backend) Build(ctx context.Context, modelfilePath, workDir, target stri
 	}
 
 	// Build the model manifest.
-	_, err = builder.BuildManifest(ctx, layers, configDesc, manifestAnnotation(), hooks.NewHooks(
+	_, err = builder.BuildManifest(ctx, layers, configDesc, manifestAnnotation(modelfile), hooks.NewHooks(
 		hooks.WithOnStart(func(name string, size int64, reader io.Reader) io.Reader {
 			return pb.Add(internalpb.NormalizePrompt("Building manifest"), name, size, reader)
 		}),
@@ -161,8 +166,9 @@ func (b *backend) process(ctx context.Context, builder build.Builder, workDir st
 }
 
 // manifestAnnotation returns the annotations for the manifest.
-func manifestAnnotation() map[string]string {
-	// placeholder for future expansion of annotations.
-	anno := map[string]string{}
+func manifestAnnotation(modelfile modelfile.Modelfile) map[string]string {
+	anno := map[string]string{
+		annotationModelfile: string(modelfile.Content()),
+	}
 	return anno
 }


### PR DESCRIPTION
This pull request includes changes to the `pkg/backend` package to improve the handling of model manifests and annotations. The key updates involve modifying the `BuildManifest` function calls and enhancing the annotation handling for model files.

Improvements to model manifest handling:

* [`pkg/backend/attach.go`](diffhunk://#diff-25a4006e1f7d4d1bb259002a032f3efe5f4b4dad94b8b3a2fccac02214301559L153-R153): Updated the `BuildManifest` function call to use `srcManifest.Annotations` instead of `manifestAnnotation()`.
* [`pkg/backend/build.go`](diffhunk://#diff-d6967c304021925580fe39f08821dc9e301bcc02a119e188d723e6939f170a5cR37-R41): Added a new constant `annotationModelfile` for the annotation key of the Modelfile.

Enhancements to annotation handling:

* [`pkg/backend/build.go`](diffhunk://#diff-d6967c304021925580fe39f08821dc9e301bcc02a119e188d723e6939f170a5cL108-R113): Modified the `BuildManifest` function call to use `manifestAnnotation(modelfile)` instead of `manifestAnnotation()`.
* [`pkg/backend/build.go`](diffhunk://#diff-d6967c304021925580fe39f08821dc9e301bcc02a119e188d723e6939f170a5cL164-R172): Updated the `manifestAnnotation` function to accept a `modelfile` parameter and include the `annotationModelfile` in the annotations map.