### PR TITLE
feat: support interceptor for build

### DIFF
--- a/pkg/backend/attach.go
+++ b/pkg/backend/attach.go
@@ -32,6 +32,7 @@ import (
 	"github.com/CloudNativeAI/modctl/pkg/backend/build"
 	buildconfig "github.com/CloudNativeAI/modctl/pkg/backend/build/config"
 	"github.com/CloudNativeAI/modctl/pkg/backend/build/hooks"
+	"github.com/CloudNativeAI/modctl/pkg/backend/build/interceptor"
 	"github.com/CloudNativeAI/modctl/pkg/backend/processor"
 	"github.com/CloudNativeAI/modctl/pkg/backend/remote"
 	"github.com/CloudNativeAI/modctl/pkg/config"
@@ -299,6 +300,10 @@ func (b *backend) getBuilder(reference string, cfg *config.Attach) (build.Builde
 		build.WithPlainHTTP(cfg.PlainHTTP),
 		build.WithInsecure(cfg.Insecure),
 	}
+	if cfg.Nydusify {
+		opts = append(opts, build.WithInterceptor(interceptor.NewNydus()))
+	}
+
 	builder, err := build.NewBuilder(outputType, b.store, repo, tag, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create builder: %w", err)

--- a/pkg/backend/build.go
+++ b/pkg/backend/build.go
@@ -26,6 +26,7 @@ import (
 	"github.com/CloudNativeAI/modctl/pkg/backend/build"
 	buildconfig "github.com/CloudNativeAI/modctl/pkg/backend/build/config"
 	"github.com/CloudNativeAI/modctl/pkg/backend/build/hooks"
+	"github.com/CloudNativeAI/modctl/pkg/backend/build/interceptor"
 	"github.com/CloudNativeAI/modctl/pkg/backend/processor"
 	"github.com/CloudNativeAI/modctl/pkg/config"
 	"github.com/CloudNativeAI/modctl/pkg/modelfile"
@@ -67,6 +68,10 @@ func (b *backend) Build(ctx context.Context, modelfilePath, workDir, target stri
 		build.WithPlainHTTP(cfg.PlainHTTP),
 		build.WithInsecure(cfg.Insecure),
 	}
+	if cfg.Nydusify {
+		opts = append(opts, build.WithInterceptor(interceptor.NewNydus()))
+	}
+
 	builder, err := build.NewBuilder(outputType, b.store, repo, tag, opts...)
 	if err != nil {
 		return fmt.Errorf("failed to create builder: %w", err)

--- a/pkg/backend/build/interceptor/interceptor.go
+++ b/pkg/backend/build/interceptor/interceptor.go
@@ -14,35 +14,20 @@
  * limitations under the License.
  */
 
-package build
+package interceptor
 
 import (
-	"github.com/CloudNativeAI/modctl/pkg/backend/build/interceptor"
+	"context"
+	"io"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-type Option func(*config)
+// ApplyDescriptorFn is a function that applies changes to the descriptor.
+type ApplyDescriptorFn func(desc *ocispec.Descriptor)
 
-// config is the configuration for the building.
-type config struct {
-	plainHTTP   bool
-	insecure    bool
-	interceptor interceptor.Interceptor
-}
-
-func WithPlainHTTP(plainHTTP bool) Option {
-	return func(c *config) {
-		c.plainHTTP = plainHTTP
-	}
-}
-
-func WithInsecure(insecure bool) Option {
-	return func(c *config) {
-		c.insecure = insecure
-	}
-}
-
-func WithInterceptor(interceptor interceptor.Interceptor) Option {
-	return func(c *config) {
-		c.interceptor = interceptor
-	}
+// Interceptor is an interface that defines the interceptor for the building stream.
+type Interceptor interface {
+	// Intercept intercepts the building stream for some customized logic, readerType is the original stream type, such as raw or tar.
+	Intercept(ctx context.Context, mediaType string, filepath string, readerType string, reader io.Reader) (ApplyDescriptorFn, error)
 }

--- a/pkg/backend/build/interceptor/nydus.go
+++ b/pkg/backend/build/interceptor/nydus.go
@@ -14,35 +14,20 @@
  * limitations under the License.
  */
 
-package build
+package interceptor
 
 import (
-	"github.com/CloudNativeAI/modctl/pkg/backend/build/interceptor"
+	"context"
+	"io"
 )
 
-type Option func(*config)
+type nydus struct{}
 
-// config is the configuration for the building.
-type config struct {
-	plainHTTP   bool
-	insecure    bool
-	interceptor interceptor.Interceptor
+func NewNydus() *nydus {
+	return &nydus{}
 }
 
-func WithPlainHTTP(plainHTTP bool) Option {
-	return func(c *config) {
-		c.plainHTTP = plainHTTP
-	}
-}
-
-func WithInsecure(insecure bool) Option {
-	return func(c *config) {
-		c.insecure = insecure
-	}
-}
-
-func WithInterceptor(interceptor interceptor.Interceptor) Option {
-	return func(c *config) {
-		c.interceptor = interceptor
-	}
+func (n *nydus) Intercept(ctx context.Context, mediaType string, filepath string, readerType string, reader io.Reader) (ApplyDescriptorFn, error) {
+	// TODO: Implement nydus interceptor
+	return nil, nil
 }

--- a/pkg/codec/codec.go
+++ b/pkg/codec/codec.go
@@ -34,6 +34,9 @@ const (
 
 // Codec is an interface for encoding and decoding the data.
 type Codec interface {
+	// Type returns the type of the codec.
+	Type() Type
+
 	// Encode encodes the target file into a reader.
 	Encode(targetFilePath, workDirPath string) (io.Reader, error)
 

--- a/pkg/codec/raw.go
+++ b/pkg/codec/raw.go
@@ -30,6 +30,11 @@ func newRaw() *raw {
 	return &raw{}
 }
 
+// Type returns the type of the codec.
+func (r *raw) Type() string {
+	return Raw
+}
+
 // Encode reads the target file into a reader.
 func (r *raw) Encode(targetFilePath, workDirPath string) (io.Reader, error) {
 	return os.Open(targetFilePath)

--- a/pkg/codec/tar.go
+++ b/pkg/codec/tar.go
@@ -30,6 +30,11 @@ func newTar() *tar {
 	return &tar{}
 }
 
+// Type returns the type of the codec.
+func (t *tar) Type() string {
+	return Tar
+}
+
 // Encode tars the target file into a reader.
 func (t *tar) Encode(targetFilePath, workDirPath string) (io.Reader, error) {
 	return archiver.Tar(targetFilePath, workDirPath)


### PR DESCRIPTION
This pull request introduces a new interceptor feature to the build process in the `pkg/backend` package. The changes include adding a new interceptor interface and implementing a specific interceptor called Nydus. The most important changes are summarized below:

### Interceptor Integration:

* [`pkg/backend/attach.go`](diffhunk://#diff-25a4006e1f7d4d1bb259002a032f3efe5f4b4dad94b8b3a2fccac02214301559R303-R306): Added the interceptor option to the builder configuration and included logic to append the interceptor if `cfg.Nydusify` is enabled.
* [`pkg/backend/build.go`](diffhunk://#diff-d6967c304021925580fe39f08821dc9e301bcc02a119e188d723e6939f170a5cR71-R74): Similar changes as in `attach.go`, adding the interceptor option to the builder configuration.

### Interceptor Implementation:

* [`pkg/backend/build/interceptor/interceptor.go`](diffhunk://#diff-9e7b1fa5d541db2bc0da2a4eebc7650e3f7eac58359d224eab85bd5e663a4c9eR1-R33): Introduced the `Interceptor` interface and the `ApplyDescriptorFn` type for applying changes to descriptors.
* [`pkg/backend/build/interceptor/nydus.go`](diffhunk://#diff-9d895d1e8e4ae90ebe88eeb289fcbff9dcd21173fb3b5cd40492a46760102402R1-R33): Implemented the `Nydus` interceptor with a placeholder for the actual interception logic.

### Builder Modifications:

* [`pkg/backend/build/builder.go`](diffhunk://#diff-8ffa00a0129cb498b64f761bd5c4133192873bb004e396b806ebd586ba2bb287R105): Updated the builder to include the interceptor in its configuration and modified the `BuildLayer` method to use the interceptor during the build process. Added a `splitReader` function to facilitate reading the build stream. [[1]](diffhunk://#diff-8ffa00a0129cb498b64f761bd5c4133192873bb004e396b806ebd586ba2bb287R105) [[2]](diffhunk://#diff-8ffa00a0129cb498b64f761bd5c4133192873bb004e396b806ebd586ba2bb287L170-R207) [[3]](diffhunk://#diff-8ffa00a0129cb498b64f761bd5c4133192873bb004e396b806ebd586ba2bb287R287-R306)

### Codec Enhancements:

* [`pkg/codec/codec.go`](diffhunk://#diff-f1af839aa40e8d1553814897ef277f31f625ed6daf6e6f44bfeb950905efabb8R37-R39): Added a `Type` method to the `Codec` interface to return the codec type.
* `pkg/codec/raw.go` and `pkg/codec/tar.go`: Implemented the `Type` method for the `raw` and `tar` codecs respectively. [[1]](diffhunk://#diff-4c12a48b48d9d0895fa3f8e3e221061a135c8768dd5af2e8c6acf7993a26f153R33-R37) [[2]](diffhunk://#diff-0fc40236986d80922fd5e4469505149e5fad7ae67b056a5c5bd16624cb9a3724R33-R37)