### PR TITLE
feat: support enable the pprof

### DIFF
--- a/pkg/config/root.go
+++ b/pkg/config/root.go
@@ -23,6 +23,8 @@ import (
 
 type Root struct {
 	StoargeDir string
+	Pprof      bool
+	PprofAddr  string
 }
 
 func NewRoot() (*Root, error) {
@@ -33,5 +35,7 @@ func NewRoot() (*Root, error) {
 
 	return &Root{
 		StoargeDir: filepath.Join(user.HomeDir, ".modctl"),
+		Pprof:      false,
+		PprofAddr:  "localhost:6060",
 	}, nil
 }


### PR DESCRIPTION
This pull request introduces changes to enable and configure pprof for performance profiling in the application. The changes primarily affect the `cmd/root.go` and `pkg/config/root.go` files. The most important changes include adding pprof-related flags and initializing the pprof server if enabled.

Changes to enable and configure pprof:

* [`cmd/root.go`](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR20-R22): Imported necessary packages for pprof (`log`, `net/http`, and `net/http/pprof`).
* [`cmd/root.go`](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR44-R55): Added a `PersistentPreRunE` function to start the pprof server if the pprof flag is enabled.
* [`cmd/root.go`](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR84-R85): Added pprof-related flags (`pprof` and `pprof-addr`) to the root command.

Configuration updates:

* [`pkg/config/root.go`](diffhunk://#diff-53d0b44d411a6bf6af7ce1c3664663057522b69d13da5769fe434605aac20817R26-R27): Added `Pprof` and `PprofAddr` fields to the `Root` struct.
* [`pkg/config/root.go`](diffhunk://#diff-53d0b44d411a6bf6af7ce1c3664663057522b69d13da5769fe434605aac20817R38-R39): Initialized the `Pprof` and `PprofAddr` fields in the `NewRoot` function.