### PR TITLE
fix: fix the nydus implementation failed when input an empty file

### DIFF
--- a/pkg/backend/build/interceptor/nydus.go
+++ b/pkg/backend/build/interceptor/nydus.go
@@ -152,6 +152,10 @@ func calcCrc32(ctx context.Context, r io.Reader, chunkSize int64) ([]uint32, err
 			hash := crc32.New(table)
 			n, err := io.Copy(hash, limitedReader)
 			if n == 0 || err == io.EOF {
+				// if no data read, return 0 as the crc32 value.
+				if len(crc32Results) == 0 {
+					return []uint32{0}, nil
+				}
 				return crc32Results, nil
 			}
 

--- a/pkg/backend/build/interceptor/nydus_test.go
+++ b/pkg/backend/build/interceptor/nydus_test.go
@@ -1,0 +1,25 @@
+package interceptor
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCalcCrc32_NormalExecution_ReturnsCorrectCrc32(t *testing.T) {
+	data := []byte("hello world")
+	expectedCrc32 := []uint32{0xc99465aa}
+
+	crc32Results, err := calcCrc32(context.Background(), bytes.NewReader(data), int64(len(data)))
+	assert.NoError(t, err)
+	assert.Equal(t, expectedCrc32, crc32Results)
+}
+
+func TestCalcCrc32_EmptyInput_ReturnsEmptySlice(t *testing.T) {
+	crc32Results, err := calcCrc32(context.Background(), bytes.NewReader([]byte{}), 10)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, crc32Results)
+	assert.Equal(t, uint32(0x0), crc32Results[0])
+}


### PR DESCRIPTION
This pull request includes changes to the `calcCrc32` function and adds corresponding tests to ensure correct behavior. The most important changes include handling empty input in the `calcCrc32` function and the addition of unit tests to verify the function's correctness.

Enhancements to `calcCrc32` function:

* [`pkg/backend/build/interceptor/nydus.go`](diffhunk://#diff-9d895d1e8e4ae90ebe88eeb289fcbff9dcd21173fb3b5cd40492a46760102402R155-R158): Modified the `calcCrc32` function to return a CRC32 value of 0 when no data is read.

Addition of unit tests:

* [`pkg/backend/build/interceptor/nydus_test.go`](diffhunk://#diff-a106585044a5f257fd05025f0afc687167c4737463438ef86586ae8e6483c12aR1-R25): Added unit tests to verify the normal execution and empty input scenarios for the `calcCrc32` function.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved checksum calculation to return a CRC32 value of zero for empty input instead of an empty result.

- **Tests**
  - Added unit tests to verify correct CRC32 calculation for both normal and empty inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->