### PR TITLE
chore: bump golangci-lint version to v2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: '0'
 
       - name: Golangci lint
-        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84
+        uses: golangci/golangci-lint-action@v7.0.0
         with:
-          version: v1.54
+          version: v2.1
           args: --verbose --timeout=10m

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,41 +1,55 @@
+version: "2"
 run:
-  timeout: 3m
   modules-download-mode: readonly
-  skip-dirs:
-    - test/mocks
-
-linters-settings:
-  gocyclo:
-    min-complexity: 100
-  gci:
-    sections:
-      - standard
-      - default
-      - prefix(github.com/CloudNativeAI/modctl)
-
+output:
+  formats:
+    text:
+      path: stdout
+      print-linter-name: true
+      print-issued-lines: true
+linters:
+  default: none
+  enable:
+    - errcheck
+    - goconst
+    - gocyclo
+    - govet
+    - misspell
+    - staticcheck
+  settings:
+    gocyclo:
+      min-complexity: 100
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - staticcheck
+        text: 'SA1019:'
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+      - test/mocks
 issues:
   new: true
-  exclude-rules:
-    - linters:
-        - staticcheck
-      text: "SA1019:"
-
-linters:
-  disable-all: true
+formatters:
   enable:
     - gci
     - gofmt
-    - golint
-    - misspell
-    - govet
-    - goconst
-    - deadcode
-    - gocyclo
-    - staticcheck
-    - errcheck
-
-output:
-  formats:
-    - format: colored-line-number
-  print-issued-lines: true
-  print-linter-name: true
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/CloudNativeAI/modctl)
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ test: fmt vet ## Run unit test and display the coverage.
 	go tool cover -func cover.out
 
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
-GOLANGCI_LINT_VERSION ?= v1.54.2
+GOLANGCI_LINT_VERSION ?= v2.1.2
 golangci-lint:
 	@[ -f $(GOLANGCI_LINT) ] || { \
 	set -e ;\


### PR DESCRIPTION
This pull request updates the GolangCI-Lint configuration and workflow to align with the latest version and improve linting capabilities. The key changes include upgrading the GolangCI-Lint version, modifying the linting workflow, and restructuring the `.golangci.yml` configuration file.

### GolangCI-Lint Version Upgrade:
* Updated the GolangCI-Lint action in `.github/workflows/lint.yml` to use version `v7.0.0` and upgraded the linting tool to `v2.1`.
* Updated the `GOLANGCI_LINT_VERSION` in the `Makefile` to `v2.1.2`.

### Linting Configuration Enhancements:
* Restructured `.golangci.yml` to use version `2`, added new output formats, enabled specific linters (e.g., `errcheck`, `goconst`, `gocyclo`), and introduced exclusion presets for better control over linting results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Upgraded golangci-lint to version 2.1.2 across workflows and development tools.
	- Updated linting configuration for improved modularity, enhanced exclusions, and revised enabled linters.
	- Adjusted GitHub Actions workflow to use the latest golangci-lint action version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->