### PR TITLE
feat: validate the sha256 after pulling the blob

### DIFF
--- a/pkg/backend/processor/options.go
+++ b/pkg/backend/processor/options.go
@@ -48,6 +48,6 @@ func WithProgressTracker(tracker *pb.ProgressBar) ProcessOption {
 var retryOpts = []retry.Option{
 	retry.Attempts(3),
 	retry.DelayType(retry.BackOffDelay),
-	retry.Delay(1 * time.Second),
-	retry.MaxDelay(5 * time.Second),
+	retry.Delay(5 * time.Second),
+	retry.MaxDelay(10 * time.Second),
 }

--- a/pkg/backend/retry.go
+++ b/pkg/backend/retry.go
@@ -25,6 +25,6 @@ import (
 var retryOpts = []retry.Option{
 	retry.Attempts(3),
 	retry.DelayType(retry.BackOffDelay),
-	retry.Delay(1 * time.Second),
-	retry.MaxDelay(5 * time.Second),
+	retry.Delay(5 * time.Second),
+	retry.MaxDelay(10 * time.Second),
 }


### PR DESCRIPTION
This pull request enhances the integrity verification process in the `pkg/backend/pull.go` file by introducing digest validation for downloaded blobs. It also includes minor import reorganization for better readability. Below are the key changes grouped by theme:

### Integrity Verification Enhancements:
* Added a SHA-256 hash computation using `io.TeeReader` in both `pullIfNotExist` and `pullAndExtractFromRemote` functions to calculate the hash of the downloaded content while reading. [[1]](diffhunk://#diff-f2435c0ad2b72cf7e41c9392804ffc2c7c29981c749a01127d335d228698ac00R140-R141) [[2]](diffhunk://#diff-f2435c0ad2b72cf7e41c9392804ffc2c7c29981c749a01127d335d228698ac00R212-R244)
* Introduced a new `validateDigest` function to ensure the computed hash matches the expected digest, improving data integrity checks. This validation is applied after content processing in both functions. [[1]](diffhunk://#diff-f2435c0ad2b72cf7e41c9392804ffc2c7c29981c749a01127d335d228698ac00R191-R197) [[2]](diffhunk://#diff-f2435c0ad2b72cf7e41c9392804ffc2c7c29981c749a01127d335d228698ac00R212-R244)
* Added error handling to abort the progress bar and return an error if the digest validation fails. [[1]](diffhunk://#diff-f2435c0ad2b72cf7e41c9392804ffc2c7c29981c749a01127d335d228698ac00R191-R197) [[2]](diffhunk://#diff-f2435c0ad2b72cf7e41c9392804ffc2c7c29981c749a01127d335d228698ac00R212-R244)

### Code Organization:
* Reorganized imports by grouping related packages together and sorting them for better readability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added SHA-256 digest validation for blobs and manifests pulled from remote repositories to ensure data integrity.
- **Bug Fixes**
  - Improved error handling to abort operations if a digest mismatch is detected during artifact pulls.
- **Tests**
  - Enhanced fetch tests with realistic file contents and corresponding digests to better simulate content retrieval.
- **Chores**
  - Increased initial and maximum retry delays to improve retry timing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->