### PR TITLE
feat: support fallback from proxy for pull

### DIFF
--- a/cmd/modelfile/generate.go
+++ b/cmd/modelfile/generate.go
@@ -61,7 +61,7 @@ func init() {
 	flags.StringVar(&generateConfig.ParamSize, "param-size", "", "specify number of model parameters, such as 8b, 16b, 32b, etc")
 	flags.StringVar(&generateConfig.Precision, "precision", "", "specify model precision, such as bf16, fp16, int8, etc")
 	flags.StringVar(&generateConfig.Quantization, "quantization", "", "specify model quantization, such as awq, gptq, etc")
-	flags.StringVarP(&generateConfig.Output, "output", "O", ".", "specify the output path of modelfilem, must be a directory")
+	flags.StringVarP(&generateConfig.Output, "output", "O", ".", "specify the output path of modelfile, must be a directory")
 	flags.BoolVar(&generateConfig.IgnoreUnrecognizedFileTypes, "ignore-unrecognized-file-types", false, "ignore the unrecognized file types in the workspace")
 	flags.BoolVar(&generateConfig.Overwrite, "overwrite", false, "overwrite the existing modelfile")
 

--- a/pkg/backend/pull.go
+++ b/pkg/backend/pull.go
@@ -49,7 +49,21 @@ func (b *backend) Pull(ctx context.Context, target string, cfg *config.Pull) err
 
 	manifestDesc, manifestReader, err := src.Manifests().FetchReference(ctx, tag)
 	if err != nil {
-		return fmt.Errorf("failed to fetch the manifest: %w", err)
+		// fallback to fetch the manifest without proxy.
+		if cfg.Proxy != "" {
+			fmt.Printf("Failed to fetch the manifest with proxy, fallback to fetch without proxy, error: %v\n", err)
+			cfg.Proxy = ""
+			src, err = remote.New(repo, remote.WithPlainHTTP(cfg.PlainHTTP), remote.WithInsecure(cfg.Insecure), remote.WithProxy(cfg.Proxy))
+			if err != nil {
+				return fmt.Errorf("failed to create the remote client: %w", err)
+			}
+			manifestDesc, manifestReader, err = src.Manifests().FetchReference(ctx, tag)
+			if err != nil {
+				return fmt.Errorf("failed to fetch the manifest: %w", err)
+			}
+		} else {
+			return fmt.Errorf("failed to fetch the manifest: %w", err)
+		}
 	}
 
 	defer manifestReader.Close()


### PR DESCRIPTION
# Support fallback from proxy for pull operations

## Description
This PR adds automatic fallback capability for proxy connections during the pull operation. When a manifest fetch fails while using a proxy, the system will automatically retry without the proxy before failing completely.