### PR TITLE
feat: support the progress writer for pull operation

### DIFF
--- a/internal/pb/pb.go
+++ b/internal/pb/pb.go
@@ -19,6 +19,7 @@ package pb
 import (
 	"fmt"
 	"io"
+	"os"
 	"sync"
 	"time"
 
@@ -46,9 +47,24 @@ type progressBar struct {
 }
 
 // NewProgressBar creates a new progress bar.
-func NewProgressBar() *ProgressBar {
+func NewProgressBar(writers ...io.Writer) *ProgressBar {
+	opts := []mpbv8.ContainerOption{
+		mpbv8.WithAutoRefresh(),
+		mpbv8.WithWidth(60),
+		mpbv8.WithRefreshRate(300 * time.Millisecond),
+	}
+
+	// If no writer specified, use stdout.
+	if len(writers) == 0 {
+		opts = append(opts, mpbv8.WithOutput(os.Stdout))
+	} else if len(writers) == 1 {
+		opts = append(opts, mpbv8.WithOutput(writers[0]))
+	} else {
+		opts = append(opts, mpbv8.WithOutput(io.MultiWriter(writers...)))
+	}
+
 	return &ProgressBar{
-		mpb:  mpbv8.New(mpbv8.WithWidth(60), mpbv8.WithRefreshRate(300*time.Millisecond)),
+		mpb:  mpbv8.New(opts...),
 		bars: make(map[string]*progressBar),
 	}
 }

--- a/pkg/backend/pull.go
+++ b/pkg/backend/pull.go
@@ -60,7 +60,7 @@ func (b *backend) Pull(ctx context.Context, target string, cfg *config.Pull) err
 	}
 
 	// create the progress bar to track the progress of push.
-	pb := internalpb.NewProgressBar()
+	pb := internalpb.NewProgressBar(cfg.ProgressWriter)
 	pb.Start()
 	defer pb.Stop()
 

--- a/pkg/config/pull.go
+++ b/pkg/config/pull.go
@@ -18,6 +18,8 @@ package config
 
 import (
 	"fmt"
+	"io"
+	"os"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
@@ -35,6 +37,7 @@ type Pull struct {
 	ExtractDir        string
 	ExtractFromRemote bool
 	Hooks             PullHooks
+	ProgressWriter    io.Writer
 }
 
 func NewPull() *Pull {
@@ -46,6 +49,7 @@ func NewPull() *Pull {
 		ExtractDir:        "",
 		ExtractFromRemote: false,
 		Hooks:             &emptyPullHook{},
+		ProgressWriter:    os.Stdout,
 	}
 }
 


### PR DESCRIPTION
This pull request introduces a configurable progress bar to enhance flexibility and usability. It allows the progress bar to output to different writers, making it more adaptable to various use cases. The changes span multiple files and involve updates to the progress bar initialization, configuration struct, and usage in the backend.

### Progress Bar Enhancements:

* **Configurable Output for Progress Bar**: Updated the `NewProgressBar` function in `internal/pb/pb.go` to accept multiple `io.Writer` arguments. If no writer is specified, it defaults to `os.Stdout`. This change enables the progress bar to support custom output destinations such as log files or multiple writers.

### Backend Integration:

* **Progress Bar Integration in Backend**: Modified the `Pull` function in `pkg/backend/pull.go` to use the configurable progress bar by passing the `ProgressWriter` from the `Pull` configuration. This ensures the progress bar's output aligns with the specified writer.

### Configuration Updates:

* **Added `ProgressWriter` to Pull Config**: Introduced a new `ProgressWriter` field of type `io.Writer` in the `Pull` struct within `pkg/config/pull.go`. This field allows users to specify the desired output for the progress bar.
* **Default `ProgressWriter` Value**: Updated the `NewPull` function in `pkg/config/pull.go` to set the default value of `ProgressWriter` to `os.Stdout`, ensuring backward compatibility and a sensible default.

### Dependency Updates:

* **Added `os` Import**: Included the `os` package in both `internal/pb/pb.go` and `pkg/config/pull.go` to support the use of `os.Stdout` for default progress bar output. [[1]](diffhunk://#diff-1dcb6035494742bd87482cc282e1220bb5691eeb276b26df9da297d18acc3408R22) [[2]](diffhunk://#diff-da1524afd5700a24c5e4a753564c7597e11e083b80efb1eb4a710758c2398afaR21-R22)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring the output destination of progress bars during pull operations. Users can now direct progress updates to custom locations instead of standard output.

- **Chores**
  - Updated internal handling to allow specifying one or more output destinations for progress reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->