### PR TITLE
chore: update the release config for static build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     tags:
       - v*
 
-permissions:  
+permissions:
   contents: read
 
 jobs:
@@ -27,6 +27,24 @@ jobs:
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b
         with:
           go-version-file: go.mod
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config
+          sudo apt update && \
+          sudo DEBIAN_FRONTEND=noninteractive apt install -y build-essential cmake pkg-config libssl-dev libssh2-1-dev zlib1g-dev libhttp-parser-dev python3 wget tar git && \
+          wget https://github.com/libgit2/libgit2/archive/refs/tags/v1.5.1.tar.gz -O libgit2-v1.5.1.tar.gz && \
+          tar -xzf libgit2-v1.5.1.tar.gz && \
+          cd libgit2-1.5.1 && \
+          mkdir build && \
+          cd build && \
+          cmake .. -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF && \
+          make -j$(nproc) && \
+          sudo make install && \
+          sudo ldconfig
+        env:
+            LIBGIT2_SYS_USE_PKG_CONFIG: "1"
 
       - name: Check GoReleaser config
         uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,11 +17,15 @@ builds:
       - amd64
       - arm64
     env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1
     ldflags:
       - -X github.com/CloudNativeAI/modctl/pkg/version.GitVersion={{ .Tag }}
       - -X github.com/CloudNativeAI/modctl/pkg/version.GitCommit={{ .ShortCommit }}
       - -X github.com/CloudNativeAI/modctl/pkg/version.BuildTime={{ .Date }}
+      - -extldflags "-static"
+    tags:
+      - static
+      - system_libgit2
 
 archives:
   - name_template: "modctl-{{ .Version }}-{{ .Os }}-{{ .Arch }}"


### PR DESCRIPTION
This pull request introduces changes to the build and release workflows to enable static builds with system `libgit2` support. The key updates include installing necessary dependencies in the GitHub Actions workflow and modifying the GoReleaser configuration to support static linking and system libraries.

### Workflow updates:
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R31-R48): Added a step to install build dependencies, including `libgit2` version 1.5.1, in the release workflow. This ensures the required libraries are available for builds.

### Build configuration updates:
* [`.goreleaser.yml`](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689L20-R28): Changed `CGO_ENABLED` from `0` to `1` to enable CGo, added `-extldflags "-static"` to the linker flags for static builds, and introduced tags `static` and `system_libgit2` to indicate the build configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the release workflow to install required system dependencies and build libgit2 from source during the release process.
	- Modified build configuration to enable CGO, enforce static linking of external libraries, and apply new build tags for improved build behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->