### PR TITLE
chore: trim the version prefix in the release download URL

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -103,8 +103,10 @@ jobs:
 
     - name: Create archive
       run: |
+        TAG=${{ github.ref_name }}
+        TAG=${TAG#v}
         mkdir -p dist
-        tar -czf dist/modctl-${{ github.ref_name }}-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz \
+        tar -czf dist/modctl-${TAG}-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz \
           LICENSE README.md modctl
 
     - name: Build deb/rpm packages
@@ -117,8 +119,10 @@ jobs:
         echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | sudo tee /etc/apt/sources.list.d/goreleaser.list
         sudo apt update
         sudo apt install nfpm
-        nfpm pkg --packager deb --config hack/nfpm.yaml --target dist/modctl-${{ github.ref_name }}-${{ matrix.goos }}-${{ matrix.goarch }}.deb
-        nfpm pkg --packager rpm --config hack/nfpm.yaml --target dist/modctl-${{ github.ref_name }}-${{ matrix.goos }}-${{ matrix.goarch }}.rpm
+        TAG=${{ github.ref_name }}
+        TAG=${TAG#v}
+        nfpm pkg --packager deb --config hack/nfpm.yaml --target dist/modctl-${TAG}-${{ matrix.goos }}-${{ matrix.goarch }}.deb
+        nfpm pkg --packager rpm --config hack/nfpm.yaml --target dist/modctl-${TAG}-${{ matrix.goos }}-${{ matrix.goarch }}.rpm
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
This pull request updates the `.github/workflows/release.yaml` file to ensure that artifact filenames and package targets handle version tags consistently by stripping the leading 'v' from `github.ref_name` when present. This improves the naming convention for release artifacts.

### Workflow updates for artifact naming:

* Updated the `tar` command in the "Create archive" step to use a conditional expression that strips the leading 'v' from `github.ref_name` when it starts with 'v'. This ensures consistent naming for tarball archives. (`[.github/workflows/release.yamlL107-R107](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL107-R107)`)
* Modified the `nfpm` commands in the "Build deb/rpm packages" step to apply the same conditional logic, ensuring that `.deb` and `.rpm` package filenames also follow the updated naming convention. (`[.github/workflows/release.yamlL120-R121](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL120-R121)`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated release artifact filenames to consistently exclude a leading 'v' from version numbers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->