### PR TITLE
fix: pass the context for retry

### DIFF
--- a/pkg/backend/build.go
+++ b/pkg/backend/build.go
@@ -129,7 +129,7 @@ func (b *backend) Build(ctx context.Context, modelfilePath, workDir, target stri
 			}),
 		))
 		return err
-	}, retryOpts...); err != nil {
+	}, append(defaultRetryOpts, retry.Context(ctx))...); err != nil {
 		return fmt.Errorf("failed to build model config: %w", err)
 	}
 
@@ -147,7 +147,7 @@ func (b *backend) Build(ctx context.Context, modelfilePath, workDir, target stri
 			}),
 		))
 		return err
-	}, retryOpts...); err != nil {
+	}, append(defaultRetryOpts, retry.Context(ctx))...); err != nil {
 		return fmt.Errorf("failed to build model manifest: %w", err)
 	}
 

--- a/pkg/backend/processor/base.go
+++ b/pkg/backend/processor/base.go
@@ -124,7 +124,7 @@ func (b *base) Process(ctx context.Context, builder build.Builder, workDir strin
 				mu.Unlock()
 
 				return nil
-			}, retryOpts...)
+			}, append(defaultRetryOpts, retry.Context(ctx))...)
 		})
 	}
 

--- a/pkg/backend/processor/options.go
+++ b/pkg/backend/processor/options.go
@@ -45,7 +45,7 @@ func WithProgressTracker(tracker *pb.ProgressBar) ProcessOption {
 	}
 }
 
-var retryOpts = []retry.Option{
+var defaultRetryOpts = []retry.Option{
 	retry.Attempts(3),
 	retry.DelayType(retry.BackOffDelay),
 	retry.Delay(5 * time.Second),

--- a/pkg/backend/pull.go
+++ b/pkg/backend/pull.go
@@ -95,7 +95,7 @@ func (b *backend) Pull(ctx context.Context, target string, cfg *config.Pull) err
 				// call the after hook.
 				cfg.Hooks.AfterPullLayer(layer, err)
 				return err
-			}, retryOpts...)
+			}, append(defaultRetryOpts, retry.Context(ctx))...)
 		})
 	}
 
@@ -112,14 +112,14 @@ func (b *backend) Pull(ctx context.Context, target string, cfg *config.Pull) err
 	// copy the config.
 	if err := retry.Do(func() error {
 		return pullIfNotExist(ctx, pb, internalpb.NormalizePrompt("Pulling config"), src, dst, manifest.Config, repo, tag)
-	}, retryOpts...); err != nil {
+	}, append(defaultRetryOpts, retry.Context(ctx))...); err != nil {
 		return fmt.Errorf("failed to pull config to local: %w", err)
 	}
 
 	// copy the manifest.
 	if err := retry.Do(func() error {
 		return pullIfNotExist(ctx, pb, internalpb.NormalizePrompt("Pulling manifest"), src, dst, manifestDesc, repo, tag)
-	}, retryOpts...); err != nil {
+	}, append(defaultRetryOpts, retry.Context(ctx))...); err != nil {
 		return fmt.Errorf("failed to pull manifest to local: %w", err)
 	}
 

--- a/pkg/backend/push.go
+++ b/pkg/backend/push.go
@@ -79,7 +79,7 @@ func (b *backend) Push(ctx context.Context, target string, cfg *config.Push) err
 		g.Go(func() error {
 			return retry.Do(func() error {
 				return pushIfNotExist(ctx, pb, internalpb.NormalizePrompt("Copying blob"), src, dst, layer, repo, tag)
-			}, retryOpts...)
+			}, append(defaultRetryOpts, retry.Context(ctx))...)
 		})
 	}
 
@@ -90,7 +90,7 @@ func (b *backend) Push(ctx context.Context, target string, cfg *config.Push) err
 	// copy the config.
 	if err := retry.Do(func() error {
 		return pushIfNotExist(ctx, pb, internalpb.NormalizePrompt("Copying config"), src, dst, manifest.Config, repo, tag)
-	}, retryOpts...); err != nil {
+	}, append(defaultRetryOpts, retry.Context(ctx))...); err != nil {
 		return fmt.Errorf("failed to push config to remote: %w", err)
 	}
 
@@ -102,7 +102,7 @@ func (b *backend) Push(ctx context.Context, target string, cfg *config.Push) err
 			Digest:    godigest.FromBytes(manifestRaw),
 			Data:      manifestRaw,
 		}, repo, tag)
-	}, retryOpts...); err != nil {
+	}, append(defaultRetryOpts, retry.Context(ctx))...); err != nil {
 		return fmt.Errorf("failed to push manifest to remote: %w", err)
 	}
 

--- a/pkg/backend/retry.go
+++ b/pkg/backend/retry.go
@@ -22,7 +22,7 @@ import (
 	retry "github.com/avast/retry-go/v4"
 )
 
-var retryOpts = []retry.Option{
+var defaultRetryOpts = []retry.Option{
 	retry.Attempts(3),
 	retry.DelayType(retry.BackOffDelay),
 	retry.Delay(5 * time.Second),


### PR DESCRIPTION
This pull request refactors the retry logic across multiple backend operations by replacing the `retryOpts` variable with a new `defaultRetryOpts` variable and appending a context-specific retry option (`retry.Context(ctx)`) in all retry calls. This change improves the consistency and context-awareness of retries.

### Retry Logic Refactor:

* **Renamed `retryOpts` to `defaultRetryOpts`**: Updated the variable name in `pkg/backend/retry.go` and `pkg/backend/processor/options.go` to better reflect its purpose as the default retry configuration. [[1]](diffhunk://#diff-8fd208b3bc210801e97df06e33385f2f7a1f343e1ac1208198be5a40f1ccf176L25-R25) [[2]](diffhunk://#diff-bfe6107c3c881846efabfc4ece7f59dd7f1bcbcb5a99104782f7a37d28cc84e4L48-R48)

* **Added context-specific retry option**: Modified retry calls in the following files to append `retry.Context(ctx)` to `defaultRetryOpts`, ensuring retries are tied to the provided context:
  - [`pkg/backend/build.go`](diffhunk://#diff-d6967c304021925580fe39f08821dc9e301bcc02a119e188d723e6939f170a5cL132-R132): Applied changes in the `Build` function for handling model config and manifest builds. [[1]](diffhunk://#diff-d6967c304021925580fe39f08821dc9e301bcc02a119e188d723e6939f170a5cL132-R132) [[2]](diffhunk://#diff-d6967c304021925580fe39f08821dc9e301bcc02a119e188d723e6939f170a5cL150-R150)
  - [`pkg/backend/processor/base.go`](diffhunk://#diff-481a7aea582e1af9469ef2aaa47876a5920678c2c124fdb6eeef24bba9258011L127-R127): Updated the `Process` function to include the context in retry logic.
  - [`pkg/backend/pull.go`](diffhunk://#diff-f2435c0ad2b72cf7e41c9392804ffc2c7c29981c749a01127d335d228698ac00L98-R98): Enhanced the `Pull` function for pulling layers, config, and manifests. [[1]](diffhunk://#diff-f2435c0ad2b72cf7e41c9392804ffc2c7c29981c749a01127d335d228698ac00L98-R98) [[2]](diffhunk://#diff-f2435c0ad2b72cf7e41c9392804ffc2c7c29981c749a01127d335d228698ac00L115-R122)
  - [`pkg/backend/push.go`](diffhunk://#diff-9dcd5308044bc9473f04358490f28c6748ec7bcf3cfa52058ef2756fb495846fL82-R82): Adjusted the `Push` function for pushing blobs, config, and manifests. [[1]](diffhunk://#diff-9dcd5308044bc9473f04358490f28c6748ec7bcf3cfa52058ef2756fb495846fL82-R82) [[2]](diffhunk://#diff-9dcd5308044bc9473f04358490f28c6748ec7bcf3cfa52058ef2756fb495846fL93-R93) [[3]](diffhunk://#diff-9dcd5308044bc9473f04358490f28c6748ec7bcf3cfa52058ef2756fb495846fL105-R105)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved retry logic to better respect cancellation and timeout by integrating context awareness into all retry operations.
  - Standardized naming of retry configuration for clarity.

- **Chores**
  - Updated internal variable names for consistency across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->