### PR TITLE
feat: support inspect the model artifact from remote registry

### DIFF
--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -22,10 +22,13 @@ import (
 	"fmt"
 
 	"github.com/CloudNativeAI/modctl/pkg/backend"
+	"github.com/CloudNativeAI/modctl/pkg/config"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
+
+var inspectConfig = config.NewInspect()
 
 // inspectCmd represents the modctl command for inspect.
 var inspectCmd = &cobra.Command{
@@ -42,7 +45,10 @@ var inspectCmd = &cobra.Command{
 
 // init initializes inspect command.
 func init() {
-	flags := rmCmd.Flags()
+	flags := inspectCmd.Flags()
+	flags.BoolVar(&inspectConfig.Remote, "remote", false, "inspect model artifact from remote registry")
+	flags.BoolVar(&inspectConfig.PlainHTTP, "plain-http", false, "use plain HTTP instead of HTTPS")
+	flags.BoolVar(&inspectConfig.Insecure, "insecure", false, "allow insecure connections")
 
 	if err := viper.BindPFlags(flags); err != nil {
 		panic(fmt.Errorf("bind cache inspect flags to viper: %w", err))
@@ -60,7 +66,7 @@ func runInspect(ctx context.Context, target string) error {
 		return fmt.Errorf("target is required")
 	}
 
-	inspected, err := b.Inspect(ctx, target)
+	inspected, err := b.Inspect(ctx, target, inspectConfig)
 	if err != nil {
 		return err
 	}

--- a/pkg/backend/attach_test.go
+++ b/pkg/backend/attach_test.go
@@ -44,7 +44,7 @@ func TestBackendGetManifest(t *testing.T) {
 		mockStore.On("PullManifest", ctx, "localhost/repo", "tag").Return(manifestBytes, "", nil)
 
 		cfg := &config.Attach{OutputRemote: false}
-		result, err := b.getManifest(ctx, "localhost/repo:tag", cfg)
+		result, err := b.getManifest(ctx, "localhost/repo:tag", cfg.OutputRemote, cfg.PlainHTTP, cfg.Insecure)
 		assert.NoError(t, err)
 		assert.Equal(t, manifest.Layers, result.Layers)
 		mockStore.AssertExpectations(t)
@@ -52,7 +52,7 @@ func TestBackendGetManifest(t *testing.T) {
 
 	t.Run("InvalidReference", func(t *testing.T) {
 		cfg := &config.Attach{OutputRemote: false}
-		_, err := b.getManifest(ctx, "invalid", cfg)
+		_, err := b.getManifest(ctx, "invalid", cfg.OutputRemote, cfg.PlainHTTP, cfg.Insecure)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to parse source reference")
 	})

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -56,7 +56,7 @@ type Backend interface {
 	Prune(ctx context.Context, dryRun, removeUntagged bool) error
 
 	// Inspect inspects the model artifact.
-	Inspect(ctx context.Context, target string) (*InspectedModelArtifact, error)
+	Inspect(ctx context.Context, target string, cfg *config.Inspect) (*InspectedModelArtifact, error)
 
 	// Extract extracts the model artifact.
 	Extract(ctx context.Context, target string, cfg *config.Extract) error

--- a/pkg/backend/inspect_test.go
+++ b/pkg/backend/inspect_test.go
@@ -22,8 +22,10 @@ import (
 	"io"
 	"testing"
 
-	"github.com/CloudNativeAI/modctl/test/mocks/storage"
 	"github.com/stretchr/testify/assert"
+
+	pkgconfig "github.com/CloudNativeAI/modctl/pkg/config"
+	"github.com/CloudNativeAI/modctl/test/mocks/storage"
 )
 
 func TestInspect(t *testing.T) {
@@ -126,13 +128,13 @@ func TestInspect(t *testing.T) {
   }
 }`
 
-	mockStore.On("PullManifest", ctx, "example.com/repo", "tag").Return([]byte(manifest), "sha256:2bc8836f5910ec63a01109e20db67c2ad7706cb19bef5a303bc86fa5572ec9a2", nil)
+	mockStore.On("PullManifest", ctx, "example.com/repo", "tag").Return([]byte(manifest), "sha256:9ca701e8784e5656e2c36f10f82410a0af4c44f859590a28a3d1519ee1eea89d", nil)
 	mockStore.On("PullBlob", ctx, "example.com/repo", "sha256:e31b55920173ba79526491fbd01efe609c1d0d72c3a83df85b2c4fe74df2eea2").Return(io.NopCloser(bytes.NewReader([]byte(config))), nil)
 
-	inspected, err := b.Inspect(ctx, target)
+	inspected, err := b.Inspect(ctx, target, &pkgconfig.Inspect{})
 	assert.NoError(t, err)
 	assert.Equal(t, "sha256:e31b55920173ba79526491fbd01efe609c1d0d72c3a83df85b2c4fe74df2eea2", inspected.ID)
-	assert.Equal(t, "sha256:2bc8836f5910ec63a01109e20db67c2ad7706cb19bef5a303bc86fa5572ec9a2", inspected.Digest)
+	assert.Equal(t, "sha256:9ca701e8784e5656e2c36f10f82410a0af4c44f859590a28a3d1519ee1eea89d", inspected.Digest)
 	assert.Equal(t, "transformer", inspected.Architecture)
 	assert.Equal(t, "2025-02-12T17:01:43+08:00", inspected.CreatedAt)
 	assert.Equal(t, "qwen2", inspected.Family)

--- a/pkg/config/inspect.go
+++ b/pkg/config/inspect.go
@@ -1,0 +1,31 @@
+/*
+ *     Copyright 2024 The CNAI Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+type Inspect struct {
+	Remote    bool
+	PlainHTTP bool
+	Insecure  bool
+}
+
+func NewInspect() *Inspect {
+	return &Inspect{
+		Remote:    false,
+		PlainHTTP: false,
+		Insecure:  false,
+	}
+}


### PR DESCRIPTION
This pull request introduces enhancements to the `inspect` command and refactors related backend methods to improve configurability and maintainability. Key changes include adding a new `Inspect` configuration struct, updating the `inspect` command to support additional flags, and refactoring backend methods to use explicit parameters instead of configuration structs.

### Enhancements to the `inspect` command:
* Added a new `Inspect` configuration struct in `pkg/config/inspect.go` to handle options like `Remote`, `PlainHTTP`, and `Insecure`. A helper function `NewInspect` initializes this struct with default values.
* Updated `cmd/inspect.go` to include new flags (`--remote`, `--plain-http`, `--insecure`) for the `inspect` command, binding them to the `Inspect` configuration struct. [[1]](diffhunk://#diff-e1112a72d67ea1111e0c19d52bd341c23830344021f7f8534ffa74df2ad51d20R25-R32) [[2]](diffhunk://#diff-e1112a72d67ea1111e0c19d52bd341c23830344021f7f8534ffa74df2ad51d20L45-R51)

### Refactoring backend methods:
* Modified the `Inspect` method in `pkg/backend/backend.go` to accept the new `Inspect` configuration struct as a parameter. Updated its implementation in `pkg/backend/inspect.go` to utilize the new configuration struct for handling remote and secure connections. [[1]](diffhunk://#diff-c65bcfe9bb457434c3e69ba3f0576d7669935f350d24e2c2c58b05b4f9c510b2L59-R59) [[2]](diffhunk://#diff-a94e5da4533561dba9ccbb2ab8b32d5c7952c5b3e6c2bfbd2a0a0cb901263388L66-R91)
* Refactored `getManifest` and `getModelConfig` methods in `pkg/backend/attach.go` to replace the `Attach` configuration struct with explicit parameters for `Remote`, `PlainHTTP`, and `Insecure`. This improves clarity and reduces dependency on configuration structs. [[1]](diffhunk://#diff-25a4006e1f7d4d1bb259002a032f3efe5f4b4dad94b8b3a2fccac02214301559L172-R172) [[2]](diffhunk://#diff-25a4006e1f7d4d1bb259002a032f3efe5f4b4dad94b8b3a2fccac02214301559L217-R217)

### Updates to tests:
* Updated test cases in `pkg/backend/attach_test.go` and `pkg/backend/inspect_test.go` to reflect the new method signatures and configuration struct usage. [[1]](diffhunk://#diff-51e6233079b9908beda48c81a6609e3cec11d80bac7d910f64295ad07f1b3293L47-R55) [[2]](diffhunk://#diff-bf4b648860bc807309b451a8c58ec58ab1d838f95822247ce74fbfdd44573013L132-R134)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added new options to the inspect command: inspect artifacts from a remote registry, use plain HTTP, and allow insecure connections.
- **Bug Fixes**
  - Corrected flag registration for the inspect command to ensure proper behavior.
- **Refactor**
  - Updated internal handling of configuration options for inspecting and attaching model artifacts to improve clarity and flexibility.
- **Tests**
  - Adjusted tests to align with updated configuration handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->