### PR TITLE
feat: support disable the progress bar

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,11 +24,12 @@ import (
 	"os/signal"
 	"syscall"
 
-	"github.com/CloudNativeAI/modctl/cmd/modelfile"
-	"github.com/CloudNativeAI/modctl/pkg/config"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
+	"github.com/CloudNativeAI/modctl/cmd/modelfile"
+	internalpb "github.com/CloudNativeAI/modctl/internal/pb"
+	"github.com/CloudNativeAI/modctl/pkg/config"
 )
 
 var rootConfig *config.Root
@@ -51,6 +52,9 @@ var rootCmd = &cobra.Command{
 				}
 			}()
 		}
+
+		// TODO: need refactor as currently use a global flag to control the progress bar render.
+		internalpb.SetDisableProgress(rootConfig.DisableProgress)
 		return nil
 	},
 }
@@ -83,6 +87,7 @@ func init() {
 	flags.StringVar(&rootConfig.StoargeDir, "storage-dir", rootConfig.StoargeDir, "specify the storage directory for modctl")
 	flags.BoolVar(&rootConfig.Pprof, "pprof", rootConfig.Pprof, "enable pprof")
 	flags.StringVar(&rootConfig.PprofAddr, "pprof-addr", rootConfig.PprofAddr, "specify the address for pprof")
+	flags.BoolVar(&rootConfig.DisableProgress, "no-progress", rootConfig.DisableProgress, "disable progress bar")
 
 	// Bind common flags.
 	if err := viper.BindPFlags(flags); err != nil {

--- a/internal/pb/pb.go
+++ b/internal/pb/pb.go
@@ -28,6 +28,16 @@ import (
 	"github.com/vbauerster/mpb/v8/decor"
 )
 
+var (
+	// disableProgress is the flag to disable progress bar.
+	disableProgress bool
+)
+
+// SetDisableProgress disables the progress bar.
+func SetDisableProgress(disable bool) {
+	disableProgress = disable
+}
+
 // NormalizePrompt normalizes the prompt string.
 func NormalizePrompt(prompt string) string {
 	return fmt.Sprintf("%s =>", prompt)
@@ -71,6 +81,11 @@ func NewProgressBar(writers ...io.Writer) *ProgressBar {
 
 // Add adds a new progress bar.
 func (p *ProgressBar) Add(prompt, name string, size int64, reader io.Reader) io.Reader {
+	// Return the reader directly if progress is disabled.
+	if disableProgress {
+		return reader
+	}
+
 	p.mu.RLock()
 	oldBar := p.bars[name]
 	p.mu.RUnlock()

--- a/pkg/backend/pull.go
+++ b/pkg/backend/pull.go
@@ -59,6 +59,11 @@ func (b *backend) Pull(ctx context.Context, target string, cfg *config.Pull) err
 		return fmt.Errorf("failed to decode the manifest: %w", err)
 	}
 
+	// TODO: need refactor as currently use a global flag to control the progress bar render.
+	if cfg.DisableProgress {
+		internalpb.SetDisableProgress(true)
+	}
+
 	// create the progress bar to track the progress of push.
 	pb := internalpb.NewProgressBar(cfg.ProgressWriter)
 	pb.Start()

--- a/pkg/config/pull.go
+++ b/pkg/config/pull.go
@@ -38,6 +38,7 @@ type Pull struct {
 	ExtractFromRemote bool
 	Hooks             PullHooks
 	ProgressWriter    io.Writer
+	DisableProgress   bool
 }
 
 func NewPull() *Pull {
@@ -50,6 +51,7 @@ func NewPull() *Pull {
 		ExtractFromRemote: false,
 		Hooks:             &emptyPullHook{},
 		ProgressWriter:    os.Stdout,
+		DisableProgress:   false,
 	}
 }
 

--- a/pkg/config/root.go
+++ b/pkg/config/root.go
@@ -22,9 +22,10 @@ import (
 )
 
 type Root struct {
-	StoargeDir string
-	Pprof      bool
-	PprofAddr  string
+	StoargeDir      string
+	Pprof           bool
+	PprofAddr       string
+	DisableProgress bool
 }
 
 func NewRoot() (*Root, error) {
@@ -34,8 +35,9 @@ func NewRoot() (*Root, error) {
 	}
 
 	return &Root{
-		StoargeDir: filepath.Join(user.HomeDir, ".modctl"),
-		Pprof:      false,
-		PprofAddr:  "localhost:6060",
+		StoargeDir:      filepath.Join(user.HomeDir, ".modctl"),
+		Pprof:           false,
+		PprofAddr:       "localhost:6060",
+		DisableProgress: false,
 	}, nil
 }


### PR DESCRIPTION
This pull request introduces a new feature to disable the progress bar rendering throughout the application. It adds a global flag `DisableProgress` to control this functionality, updates related configurations, and modifies the progress bar logic accordingly. Additionally, it includes minor refactoring and comments to highlight areas for future improvement.

### Feature: Disable Progress Bar Rendering

* [`cmd/root.go`](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fR90): Added a new flag `--no-progress` to the CLI to allow users to disable the progress bar. This flag is bound to the `DisableProgress` field in the `Root` configuration.
* [`internal/pb/pb.go`](diffhunk://#diff-1dcb6035494742bd87482cc282e1220bb5691eeb276b26df9da297d18acc3408R31-R40): Introduced a global variable `disableProgress` and a setter function `SetDisableProgress` to control the progress bar rendering. Updated the `Add` method in `ProgressBar` to skip rendering when `disableProgress` is true. [[1]](diffhunk://#diff-1dcb6035494742bd87482cc282e1220bb5691eeb276b26df9da297d18acc3408R31-R40) [[2]](diffhunk://#diff-1dcb6035494742bd87482cc282e1220bb5691eeb276b26df9da297d18acc3408R84-R88)

### Configuration Updates

* [`pkg/config/root.go`](diffhunk://#diff-53d0b44d411a6bf6af7ce1c3664663057522b69d13da5769fe434605aac20817R28): Added the `DisableProgress` field to the `Root` configuration and initialized it with a default value of `false`. [[1]](diffhunk://#diff-53d0b44d411a6bf6af7ce1c3664663057522b69d13da5769fe434605aac20817R28) [[2]](diffhunk://#diff-53d0b44d411a6bf6af7ce1c3664663057522b69d13da5769fe434605aac20817R41)
* [`pkg/config/pull.go`](diffhunk://#diff-da1524afd5700a24c5e4a753564c7597e11e083b80efb1eb4a710758c2398afaR41): Added the `DisableProgress` field to the `Pull` configuration and updated the `NewPull` function to initialize it. [[1]](diffhunk://#diff-da1524afd5700a24c5e4a753564c7597e11e083b80efb1eb4a710758c2398afaR41) [[2]](diffhunk://#diff-da1524afd5700a24c5e4a753564c7597e11e083b80efb1eb4a710758c2398afaR54)

### Integration with Backend Logic

* [`pkg/backend/pull.go`](diffhunk://#diff-f2435c0ad2b72cf7e41c9392804ffc2c7c29981c749a01127d335d228698ac00R62-R66): Updated the `Pull` method to set the global `disableProgress` flag based on the `DisableProgress` field in the `Pull` configuration. Added a comment noting the need for refactoring this approach.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new command-line flag to disable progress bar display during operations.
- **Bug Fixes**
  - Progress bar rendering can now be globally disabled based on user preference.
- **Chores**
  - Improved internal handling of progress bar settings for consistency across commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->