### PR TITLE
feat(nydusify): support convert raw format of modctl artifact

### DIFF
--- a/pkg/backend/build/interceptor/nydus.go
+++ b/pkg/backend/build/interceptor/nydus.go
@@ -36,8 +36,10 @@ const (
 )
 
 var mediaTypeChunkSizeMap = map[string]int{
-	modelspec.MediaTypeModelWeight:  64 * 1024 * 1024,
-	modelspec.MediaTypeModelDataset: 64 * 1024 * 1024,
+	modelspec.MediaTypeModelWeight:     64 * 1024 * 1024,
+	modelspec.MediaTypeModelWeightRaw:  64 * 1024 * 1024,
+	modelspec.MediaTypeModelDataset:    64 * 1024 * 1024,
+	modelspec.MediaTypeModelDatasetRaw: 64 * 1024 * 1024,
 }
 
 var table = crc32.MakeTable(crc32.Castagnoli)


### PR DESCRIPTION
This pull request updates the `mediaTypeChunkSizeMap` in the `nydus.go` file to include new media types for raw model weights and datasets. These changes ensure that the chunk size mapping accommodates additional media types.

### Updates to chunk size mapping:

* [`pkg/backend/build/interceptor/nydus.go`](diffhunk://#diff-9d895d1e8e4ae90ebe88eeb289fcbff9dcd21173fb3b5cd40492a46760102402R40-R42): Added `modelspec.MediaTypeModelWeightRaw` and `modelspec.MediaTypeModelDatasetRaw` to the `mediaTypeChunkSizeMap` with a chunk size of `64 * 1024 * 1024`.