### PR TITLE
refactor: move the PullByDragonfly as private method

### DIFF
--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -73,14 +73,8 @@ func runPull(ctx context.Context, target string) error {
 		return fmt.Errorf("target is required")
 	}
 
-	if pullConfig.DragonflyEndpoint != "" {
-		if err := b.PullByDragonfly(ctx, target, pullConfig); err != nil {
-			return err
-		}
-	} else {
-		if err := b.Pull(ctx, target, pullConfig); err != nil {
-			return err
-		}
+	if err := b.Pull(ctx, target, pullConfig); err != nil {
+		return err
 	}
 
 	fmt.Printf("Successfully pulled model artifact: %s\n", target)

--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -40,9 +40,6 @@ type Backend interface {
 	// Pull pulls an artifact from a registry.
 	Pull(ctx context.Context, target string, cfg *config.Pull) error
 
-	// PullByDragonfly pulls an artifact from a registry by Dragonfly.
-	PullByDragonfly(ctx context.Context, target string, cfg *config.Pull) error
-
 	// Fetch fetches partial files to the output.
 	Fetch(ctx context.Context, target string, cfg *config.Fetch) error
 

--- a/pkg/backend/pull.go
+++ b/pkg/backend/pull.go
@@ -35,6 +35,11 @@ import (
 
 // Pull pulls an artifact from a registry.
 func (b *backend) Pull(ctx context.Context, target string, cfg *config.Pull) error {
+	// pullByDragonfly is called if a Dragonfly endpoint is specified in the configuration.
+	if cfg.DragonflyEndpoint != "" {
+		return b.pullByDragonfly(ctx, target, cfg)
+	}
+
 	// parse the repository and tag from the target.
 	ref, err := ParseReference(target)
 	if err != nil {

--- a/pkg/backend/pull_by_d7y.go
+++ b/pkg/backend/pull_by_d7y.go
@@ -45,8 +45,8 @@ const (
 	mediaTypeTarSuffix = ".tar"
 )
 
-// PullByDragonfly pulls and hardlinks blobs from Dragonfly gRPC service for remote extraction.
-func (b *backend) PullByDragonfly(ctx context.Context, target string, cfg *config.Pull) error {
+// pullByDragonfly pulls and hardlinks blobs from Dragonfly gRPC service for remote extraction.
+func (b *backend) pullByDragonfly(ctx context.Context, target string, cfg *config.Pull) error {
 	// Parse reference and initialize remote client.
 	ref, err := ParseReference(target)
 	if err != nil {

--- a/test/mocks/backend/backend.go
+++ b/test/mocks/backend/backend.go
@@ -602,54 +602,6 @@ func (_c *Backend_Pull_Call) RunAndReturn(run func(context.Context, string, *con
 	return _c
 }
 
-// PullByDragonfly provides a mock function with given fields: ctx, target, cfg
-func (_m *Backend) PullByDragonfly(ctx context.Context, target string, cfg *config.Pull) error {
-	ret := _m.Called(ctx, target, cfg)
-
-	if len(ret) == 0 {
-		panic("no return value specified for PullByDragonfly")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, *config.Pull) error); ok {
-		r0 = rf(ctx, target, cfg)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// Backend_PullByDragonfly_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PullByDragonfly'
-type Backend_PullByDragonfly_Call struct {
-	*mock.Call
-}
-
-// PullByDragonfly is a helper method to define mock.On call
-//   - ctx context.Context
-//   - target string
-//   - cfg *config.Pull
-func (_e *Backend_Expecter) PullByDragonfly(ctx interface{}, target interface{}, cfg interface{}) *Backend_PullByDragonfly_Call {
-	return &Backend_PullByDragonfly_Call{Call: _e.mock.On("PullByDragonfly", ctx, target, cfg)}
-}
-
-func (_c *Backend_PullByDragonfly_Call) Run(run func(ctx context.Context, target string, cfg *config.Pull)) *Backend_PullByDragonfly_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(*config.Pull))
-	})
-	return _c
-}
-
-func (_c *Backend_PullByDragonfly_Call) Return(_a0 error) *Backend_PullByDragonfly_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *Backend_PullByDragonfly_Call) RunAndReturn(run func(context.Context, string, *config.Pull) error) *Backend_PullByDragonfly_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // Push provides a mock function with given fields: ctx, target, cfg
 func (_m *Backend) Push(ctx context.Context, target string, cfg *config.Push) error {
 	ret := _m.Called(ctx, target, cfg)


### PR DESCRIPTION
This pull request refactors the handling of Dragonfly-based artifact pulling by removing the `PullByDragonfly` method from the `Backend` interface and consolidating its logic into the existing `Pull` method. This simplifies the codebase by reducing redundancy and improving maintainability.

### Backend Interface Refactoring:
* Removed the `PullByDragonfly` method from the `Backend` interface in `pkg/backend/backend.go`. The logic is now encapsulated within the `Pull` method.

### Consolidation of Dragonfly Logic:
* Updated the `Pull` method in `pkg/backend/pull.go` to internally handle Dragonfly-specific logic when a `DragonflyEndpoint` is specified. This eliminates the need for a separate `PullByDragonfly` method.

### Method Renaming:
* Renamed the `PullByDragonfly` method to `pullByDragonfly` in `pkg/backend/pull_by_d7y.go` to reflect its new role as an internal helper function.

### Code Cleanup:
* Removed the now-unused `PullByDragonfly` logic and associated mock functions from `test/mocks/backend/backend.go`. This includes the mock implementation and helper methods for testing.

### Simplification of Pull Command:
* Simplified the `runPull` function in `cmd/pull.go` by removing the conditional logic for `PullByDragonfly` and relying solely on the updated `Pull` method.