### PR TITLE
refactor: increase the retry timeout and wrap the error for retry

### DIFF
--- a/internal/pb/pb.go
+++ b/internal/pb/pb.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	humanize "github.com/dustin/go-humanize"
+	"github.com/sirupsen/logrus"
 	mpbv8 "github.com/vbauerster/mpb/v8"
 	"github.com/vbauerster/mpb/v8/decor"
 )
@@ -154,7 +155,7 @@ func (p *ProgressBar) Abort(name string, err error) {
 	p.mu.RUnlock()
 
 	if ok {
-		// TODO: Log error message.
+		logrus.Errorf("abort the progress bar[%s] as error occurred: %v", name, err)
 		bar.Abort(true)
 	}
 }

--- a/pkg/backend/processor/base.go
+++ b/pkg/backend/processor/base.go
@@ -145,13 +145,14 @@ func (b *base) Process(ctx context.Context, builder build.Builder, workDir strin
 					}),
 				))
 				if err != nil {
-					logrus.Errorf("processor: failed to build layer for %s file %s: %v", b.name, path, err)
+					err = fmt.Errorf("processor: failed to build layer for %s file %s: %w", b.name, path, err)
+					logrus.Error(err)
 					cancel()
 					return err
 				}
 
-				mu.Lock()
 				logrus.Debugf("processor: successfully built %s layer for file %s [digest: %s, size: %d]", b.name, path, desc.Digest, desc.Size)
+				mu.Lock()
 				descriptors = append(descriptors, desc)
 				mu.Unlock()
 

--- a/pkg/backend/processor/options.go
+++ b/pkg/backend/processor/options.go
@@ -46,8 +46,8 @@ func WithProgressTracker(tracker *pb.ProgressBar) ProcessOption {
 }
 
 var defaultRetryOpts = []retry.Option{
-	retry.Attempts(3),
+	retry.Attempts(4),
 	retry.DelayType(retry.BackOffDelay),
-	retry.Delay(5 * time.Second),
-	retry.MaxDelay(10 * time.Second),
+	retry.Delay(10 * time.Second),
+	retry.MaxDelay(20 * time.Second),
 }

--- a/pkg/backend/pull.go
+++ b/pkg/backend/pull.go
@@ -119,10 +119,10 @@ func (b *backend) Pull(ctx context.Context, target string, cfg *config.Pull) err
 				// call the after hook.
 				cfg.Hooks.AfterPullLayer(layer, err)
 				if err != nil {
-					logrus.Debugf("pull: failed to process layer %s: %v", layer.Digest, err)
-				} else {
-					logrus.Debugf("pull: successfully processed layer %s", layer.Digest)
+					err = fmt.Errorf("pull: failed to process layer %s: %w", layer.Digest, err)
+					logrus.Error(err)
 				}
+
 				return err
 			}, append(defaultRetryOpts, retry.Context(ctx))...)
 		})

--- a/pkg/backend/retry.go
+++ b/pkg/backend/retry.go
@@ -23,8 +23,8 @@ import (
 )
 
 var defaultRetryOpts = []retry.Option{
-	retry.Attempts(3),
+	retry.Attempts(4),
 	retry.DelayType(retry.BackOffDelay),
-	retry.Delay(5 * time.Second),
-	retry.MaxDelay(10 * time.Second),
+	retry.Delay(10 * time.Second),
+	retry.MaxDelay(20 * time.Second),
 }


### PR DESCRIPTION
This pull request introduces logging enhancements and updates to retry configurations across the codebase. The changes improve error visibility by adding detailed logs and adjust retry mechanisms to handle failures more robustly.

### Logging Enhancements:
* Added the `logrus` dependency to `internal/pb/pb.go` for structured logging.
* Enhanced the `Abort` method in `internal/pb/pb.go` to log errors when aborting a progress bar.
* Updated error handling in `pkg/backend/processor/base.go` and `pkg/backend/pull.go` to log errors using `logrus.Error` for better traceability. [[1]](diffhunk://#diff-481a7aea582e1af9469ef2aaa47876a5920678c2c124fdb6eeef24bba9258011L148-R155) [[2]](diffhunk://#diff-f2435c0ad2b72cf7e41c9392804ffc2c7c29981c749a01127d335d228698ac00L122-R125)
* Added debug and error logs in `pkg/backend/pull_by_d7y.go` to provide detailed information during layer processing.

### Retry Configuration Updates:
* Increased the default retry attempts from 3 to 4 and adjusted delay values for retries in `pkg/backend/processor/options.go` and `pkg/backend/retry.go`. Delays were updated to 10 seconds with a maximum of 20 seconds to improve resilience. [[1]](diffhunk://#diff-bfe6107c3c881846efabfc4ece7f59dd7f1bcbcb5a99104782f7a37d28cc84e4L49-R52) [[2]](diffhunk://#diff-8fd208b3bc210801e97df06e33385f2f7a1f343e1ac1208198be5a40f1ccf176L26-R29)