### PR TITLE
ci(release): switch build tag from disable_libgit2 to enable_libgit2

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,7 +77,7 @@ jobs:
         GOARCH: ${{ matrix.goarch }}
       run: |
         go build \
-          -tags "static system_libgit2" \
+          -tags "static system_libgit2 enable_libgit2" \
           -ldflags "-X github.com/CloudNativeAI/modctl/pkg/version.GitVersion=${{ github.ref_name }} \
                     -X github.com/CloudNativeAI/modctl/pkg/version.GitCommit=$(git rev-parse --short HEAD) \
                     -X github.com/CloudNativeAI/modctl/pkg/version.BuildTime=$(date -u +'%Y-%m-%dT%H:%M:%SZ') \
@@ -94,7 +94,7 @@ jobs:
         CGO_LDFLAGS: "-lgit2 -lz -liconv -Wl,-rpath,/Users/runner/work/modctl/modctl/libgit2-1.5.1/build"
       run: |
         go build \
-          -tags "static system_libgit2" \
+          -tags "static system_libgit2 enable_libgit2" \
           -ldflags "-X github.com/CloudNativeAI/modctl/pkg/version.GitVersion=${{ github.ref_name }} \
                     -X github.com/CloudNativeAI/modctl/pkg/version.GitCommit=$(git rev-parse --short HEAD) \
                     -X github.com/CloudNativeAI/modctl/pkg/version.BuildTime=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \

--- a/pkg/source/git_gogit.go
+++ b/pkg/source/git_gogit.go
@@ -1,4 +1,4 @@
-//go:build disable_libgit2
+//go:build !enable_libgit2
 
 /*
  *     Copyright 2025 The CNAI Authors

--- a/pkg/source/git_libgit2.go
+++ b/pkg/source/git_libgit2.go
@@ -1,4 +1,4 @@
-//go:build !disable_libgit2
+//go:build enable_libgit2
 
 /*
  *     Copyright 2025 The CNAI Authors


### PR DESCRIPTION
This pull request introduces changes to enable support for `libgit2` in the project. The modifications include updates to build tags and workflow configurations to ensure compatibility with the library. Below is a summary of the most important changes:

### Workflow updates:

* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL80-R80): Updated the build tags in the `go build` command to include `enable_libgit2`, ensuring the library is enabled during the build process. [[1]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL80-R80) [[2]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL97-R97)

### Code updates:

* [`pkg/source/git_gogit.go`](diffhunk://#diff-9231841e3a99accdb471c7cf5b335f91af33d04da50f1b9f47fbde168416dd93L1-R1): Changed the build constraint from `disable_libgit2` to `!enable_libgit2` to align with the new build tag structure.
* [`pkg/source/git_libgit2.go`](diffhunk://#diff-4b612300c7feaa1a2a8ad1180bb4af0f6dc65e15c7e8962746e638d4fcba9ccaL1-R1): Updated the build constraint from `!disable_libgit2` to `enable_libgit2` to explicitly enable `libgit2` support.