### PR TITLE
fix: ensure the file type match pattern includes folder case

### DIFF
--- a/pkg/modelfile/constants.go
+++ b/pkg/modelfile/constants.go
@@ -434,7 +434,7 @@ func IsFileType(filename string, patterns []string) bool {
 	lowerFilename := strings.ToLower(filename)
 	for _, pattern := range patterns {
 		// Convert pattern to lowercase for case-insensitive comparison
-		matched, err := filepath.Match(strings.ToLower(pattern), lowerFilename)
+		matched, err := filepath.Match(strings.ToLower(pattern), filepath.Base(lowerFilename))
 		if err == nil && matched {
 			return true
 		}

--- a/pkg/modelfile/constants_test.go
+++ b/pkg/modelfile/constants_test.go
@@ -20,6 +20,10 @@ func TestIsFileType(t *testing.T) {
 		{"script.py", []string{"*.py", "*.sh"}, true},
 		{"script.sh", []string{"*.py", "*.sh"}, true},
 		{"script.bash", []string{"*.py", "*.sh"}, false},
+		{"folder/config.json", []string{"*.json", "*.yaml"}, true},
+		{"FOLDER/config.json", []string{"*.json", "*.yaml"}, true},
+		{"folder/CONFIG.JSON", []string{"*.json", "*.yaml"}, true},
+		{"folder\\config.json", []string{"*.json", "*.yaml"}, true},
 	}
 
 	assert := assert.New(t)


### PR DESCRIPTION
This pull request improves the file type matching logic in `pkg/modelfile/constants.go` and updates its corresponding tests in `pkg/modelfile/constants_test.go`. The main change ensures that pattern matching is performed only against the base filename, not the full path, making the function more reliable for typical use cases.

File type matching improvements:

* Updated `IsFileType` to use `filepath.Base(lowerFilename)` when matching patterns, so only the file name (not the full path) is considered, fixing issues with files in subfolders.

Testing enhancements:

* Added a new test case to verify that matching works for files inside folders, e.g., `"folder/config.json"` matches `"*.json"`.