### PR TITLE
feat(build): add flag to omit creation timestamp for reproducible builds

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -62,6 +62,7 @@ func init() {
 	// TODO: set the raw flag to true by default in future.
 	flags.BoolVar(&buildConfig.Raw, "raw", false, "turning on this flag will build model artifact layers in raw format")
 	flags.BoolVar(&buildConfig.Reasoning, "reasoning", false, "turning on this flag will mark this model as reasoning model in the config")
+	flags.BoolVar(&buildConfig.NoCreationTime, "no-creation-time", false, "turning on this flag will not set createdAt in the config, which will be helpful for repeated builds")
 
 	if err := viper.BindPFlags(flags); err != nil {
 		panic(fmt.Errorf("bind cache list flags to viper: %w", err))

--- a/pkg/backend/build.go
+++ b/pkg/backend/build.go
@@ -113,6 +113,7 @@ func (b *backend) Build(ctx context.Context, modelfilePath, workDir, target stri
 		SourceURL:      sourceInfo.URL,
 		SourceRevision: revision,
 		Reasoning:      cfg.Reasoning,
+		NoCreationTime: cfg.NoCreationTime,
 	}, layers)
 	if err != nil {
 		return fmt.Errorf("failed to build model config: %w", err)

--- a/pkg/backend/build/builder.go
+++ b/pkg/backend/build/builder.go
@@ -257,13 +257,16 @@ func BuildModelConfig(modelConfig *buildconfig.Model, layers []ocispec.Descripto
 		}
 	}
 
-	createdAt := time.Now()
 	descriptor := modelspec.ModelDescriptor{
-		CreatedAt: &createdAt,
 		Family:    modelConfig.Family,
 		Name:      modelConfig.Name,
 		SourceURL: modelConfig.SourceURL,
 		Revision:  modelConfig.SourceRevision,
+	}
+
+	if !modelConfig.NoCreationTime {
+		createdAt := time.Now()
+		descriptor.CreatedAt = &createdAt
 	}
 
 	diffIDs := make([]godigest.Digest, 0, len(layers))

--- a/pkg/backend/build/config/model.go
+++ b/pkg/backend/build/config/model.go
@@ -28,4 +28,5 @@ type Model struct {
 	SourceURL      string
 	SourceRevision string
 	Reasoning      bool
+	NoCreationTime bool
 }

--- a/pkg/config/build.go
+++ b/pkg/config/build.go
@@ -35,6 +35,7 @@ type Build struct {
 	SourceRevision string
 	Raw            bool
 	Reasoning      bool
+	NoCreationTime bool
 }
 
 func NewBuild() *Build {
@@ -50,6 +51,7 @@ func NewBuild() *Build {
 		SourceRevision: "",
 		Raw:            false,
 		Reasoning:      false,
+		NoCreationTime: false,
 	}
 }
 


### PR DESCRIPTION
This pull request introduces a new `--no-creation-time` flag to the build process, allowing users to optionally omit the `createdAt` timestamp from the model configuration. This is particularly useful for achieving reproducible builds, as the timestamp would otherwise change with each build. The change is implemented by adding the flag to the CLI, propagating it through the configuration structs, and conditionally setting the creation time during model config generation.

**New Build Flag for Reproducibility:**

* Added a `--no-creation-time` boolean flag to the CLI in `cmd/build.go`, allowing users to skip setting the `createdAt` field in the model config for repeated builds.

**Configuration and Propagation:**

* Extended the `Build` struct in `pkg/config/build.go` and the `Model` struct in `pkg/backend/build/config/model.go` to include a `NoCreationTime` field, ensuring the flag is tracked through the build process. [[1]](diffhunk://#diff-4fe11c9ce5925fd1222a68db9e81677689727dcf5e2ea068f7e2407671752adfR38) [[2]](diffhunk://#diff-3fef97cd567320a3dee119da2f36f48af00239e07329f2eb9133911d84642b88R31)
* Updated the `NewBuild` constructor to initialize `NoCreationTime` to `false` by default.
* Passed the `NoCreationTime` value through the backend build logic to the model config builder in `pkg/backend/build.go`.

**Conditional Creation Time Handling:**

* Modified the model config builder in `pkg/backend/build/builder.go` to only set the `createdAt` field if `NoCreationTime` is not enabled, ensuring reproducibility when the flag is used.