### PR TITLE
fix: handle spaces in file paths in Modelfile parsing

### DIFF
--- a/pkg/modelfile/modelfile_test.go
+++ b/pkg/modelfile/modelfile_test.go
@@ -1308,8 +1308,8 @@ MODEL model weights.bin
 CODE inference script.py
 DOC README file.md
 `,
-			expectError: true,
-			description: "Unquoted paths with spaces should cause parsing errors",
+			expectError: false,
+			description: "Unquoted paths with spaces are now handled correctly by joining arguments",
 		},
 		{
 			name: "quoted_paths_with_spaces",

--- a/pkg/modelfile/parser/args_parser.go
+++ b/pkg/modelfile/parser/args_parser.go
@@ -18,18 +18,24 @@ package parser
 
 import (
 	"errors"
+	"strings"
 )
 
 // parseStringArgs parses the string type of args and returns a Node, for example:
 // "MODEL foo" args' value is "foo".
+// If multiple args are provided (due to unquoted spaces), they are joined with spaces.
+// This handles cases like: CONFIG path with spaces/file.json
 func parseStringArgs(args []string, start, end int) (Node, error) {
-	if len(args) != 1 {
-		return nil, errors.New("invalid args")
-	}
-
-	if args[0] == "" {
+	if len(args) == 0 {
 		return nil, errors.New("empty args")
 	}
 
-	return NewNode(args[0], start, end), nil
+	// Join all arguments with spaces to handle unquoted file paths with spaces
+	joined := strings.Join(args, " ")
+
+	if joined == "" {
+		return nil, errors.New("empty args")
+	}
+
+	return NewNode(joined, start, end), nil
 }

--- a/pkg/modelfile/parser/args_parser.go
+++ b/pkg/modelfile/parser/args_parser.go
@@ -33,7 +33,7 @@ func parseStringArgs(args []string, start, end int) (Node, error) {
 	// Join all arguments with spaces to handle unquoted file paths with spaces
 	joined := strings.Join(args, " ")
 
-	if joined == "" {
+	if strings.TrimSpace(joined) == "" {
 		return nil, errors.New("empty args")
 	}
 

--- a/pkg/modelfile/parser/args_parser_test.go
+++ b/pkg/modelfile/parser/args_parser_test.go
@@ -38,6 +38,12 @@ func TestParseStringArgs(t *testing.T) {
 		// Additional test cases for spaces in file paths
 		{[]string{"path", "with", "spaces/file.json"}, 11, 12, false, "path with spaces/file.json"},
 		{[]string{"example", "workflows_Wan2.1/image_to_video_wan_480p_example.json"}, 13, 14, false, "example workflows_Wan2.1/image_to_video_wan_480p_example.json"},
+		// Test cases for whitespace handling
+		{[]string{" "}, 15, 16, true, ""},                                               // Whitespace-only argument should be rejected
+		{[]string{"", ""}, 17, 18, true, ""},                                            // Multiple empty string arguments should be rejected
+		{[]string{" a "}, 19, 20, false, " a "},                                         // Arguments with leading/trailing spaces should be preserved
+		{[]string{"  ", "   "}, 21, 22, true, ""},                                       // Multiple whitespace-only arguments should be rejected
+		{[]string{" path ", "with", " spaces "}, 23, 24, false, " path  with  spaces "}, // Mixed whitespace should be preserved
 	}
 
 	assert := assert.New(t)

--- a/pkg/modelfile/parser/args_parser_test.go
+++ b/pkg/modelfile/parser/args_parser_test.go
@@ -33,8 +33,11 @@ func TestParseStringArgs(t *testing.T) {
 		{[]string{"foo"}, 1, 2, false, "foo"},
 		{[]string{"bar"}, 3, 4, false, "bar"},
 		{[]string{}, 5, 6, true, ""},
-		{[]string{"foo", "bar"}, 7, 8, true, ""},
+		{[]string{"foo", "bar"}, 7, 8, false, "foo bar"}, // Now handles multiple args by joining
 		{[]string{""}, 9, 10, true, ""},
+		// Additional test cases for spaces in file paths
+		{[]string{"path", "with", "spaces/file.json"}, 11, 12, false, "path with spaces/file.json"},
+		{[]string{"example", "workflows_Wan2.1/image_to_video_wan_480p_example.json"}, 13, 14, false, "example workflows_Wan2.1/image_to_video_wan_480p_example.json"},
 	}
 
 	assert := assert.New(t)


### PR DESCRIPTION
## Summary

Fixes #207 - Resolves the issue where Modelfile parsing would fail with 'invalid args' error when file paths contained spaces without quotes.

## Problem

When using auto-generated Modelfiles with file paths containing spaces (like `CONFIG example workflows_Wan2.1/image_to_video_wan_480p_example.json`), the parser would fail with:
```
Error: failed to parse modelfile: parse command line error on line X: invalid args
```

## Solution

Modified the `parseStringArgs()` function in `pkg/modelfile/parser/args_parser.go` to:
- Join multiple arguments with spaces instead of requiring exactly 1 argument
- Handle unquoted paths like `CONFIG path with spaces/file.json`
- Maintain full backward compatibility with quoted paths

## Changes Made

- **Core Fix**: Updated `parseStringArgs()` to use `strings.Join(args, " ")` for multiple arguments
- **Updated Tests**: Modified existing tests and added comprehensive test coverage for edge cases  
- **Fixed Integration Test**: Updated modelfile integration test to reflect new expected behavior

## Testing

**All tests pass**:
- Unit tests: `go test ./pkg/modelfile/parser/`
- Integration tests: `go test ./pkg/modelfile/`
- Manual testing with comprehensive scenarios

**Backward Compatibility**:
- Quoted paths still work: `CONFIG "path with spaces/file.json"`
- Regular paths still work: `CONFIG regular_file.json`
- Mixed usage in same Modelfile works

## Example Usage

**Before (would fail):**
```dockerfile
CONFIG example workflows_Wan2.1/image_to_video_wan_480p_example.json
# Error: parse command line error on line X: invalid args
```

**After (now works):**
```dockerfile
# Both of these now work:
CONFIG example workflows_Wan2.1/image_to_video_wan_480p_example.json
CONFIG "example workflows_Wan2.1/image_to_video_wan_480p_example.json"
```

This makes auto-generated Modelfiles more robust and user-friendly while maintaining full backward compatibility.