### PR TITLE
fix(backend): correct authorization header assembly

### DIFF
--- a/pkg/backend/pull_by_d7y.go
+++ b/pkg/backend/pull_by_d7y.go
@@ -163,7 +163,8 @@ func getAuthToken(ctx context.Context, src *remote.Repository, registry, repo st
 		return "", fmt.Errorf("failed to empty token from cache")
 	}
 
-	return token, nil
+	// Assemble the full authorization token by prepending the scheme (e.g., "Bearer" or "Basic").
+	return fmt.Sprintf("%s %s", scheme, token), nil
 }
 
 // buildBlobURL constructs the URL for a blob.
@@ -232,7 +233,7 @@ func downloadAndExtractLayer(ctx context.Context, pb *internalpb.ProgressBar, cl
 			Type:     common.TaskType_STANDARD,
 			Priority: common.Priority_LEVEL6,
 			RequestHeader: map[string]string{
-				"Authorization": fmt.Sprintf("Bearer %s", authToken),
+				"Authorization": authToken,
 			},
 			OutputPath:    &outputPath,
 			ForceHardLink: false,


### PR DESCRIPTION
This pull request updates the authentication handling for registry requests in `pkg/backend/pull_by_d7y.go`. The main change is to ensure the correct authentication scheme prefix is included in the `Authorization` header, improving compatibility with registries that expect different schemes.

Authentication handling improvements:

* The `getAuthToken` function now assembles the authentication token with the appropriate scheme prefix (e.g., "Bearer" or "Basic") before returning it, ensuring the `Authorization` header is correctly formatted.
* The `Authorization` header in layer download requests now uses the full token (including the scheme prefix) instead of hardcoding "Bearer", allowing support for multiple authentication schemes.