### PR TITLE
docs(getting-started): update install command to use main branch

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -5,7 +5,7 @@
 ### Binary
 
 ```shell
-$ go install github.com/modelpack/modctl@latest
+$ go install github.com/modelpack/modctl@main
 ```
 
 ### Build from source


### PR DESCRIPTION
This pull request updates the installation instructions in the `docs/getting-started.md` file to use the latest code from the `main` branch instead of the latest release. This ensures that users installing via the binary command get the most recent changes.

Documentation update:

* Changed the `go install` command to use `@main` instead of `@latest` for installing `modctl`, ensuring installation from the current main branch.

Closes: https://github.com/modelpack/modctl/issues/307