### PR TITLE
feat(remote): add custom headers to HTTP requests

### DIFF
--- a/pkg/backend/remote/client.go
+++ b/pkg/backend/remote/client.go
@@ -26,6 +26,8 @@ import (
 	"oras.land/oras-go/v2/registry/remote/auth"
 	"oras.land/oras-go/v2/registry/remote/credentials"
 	"oras.land/oras-go/v2/registry/remote/retry"
+
+	"github.com/modelpack/modctl/pkg/version"
 )
 
 type Repository = remote.Repository
@@ -78,10 +80,15 @@ func New(repo string, opts ...Option) (*remote.Repository, error) {
 		return nil, fmt.Errorf("failed to create credential store: %w", err)
 	}
 
+	// Add custom headers to the request.
+	header := make(http.Header)
+	header.Set("User-Agent", fmt.Sprintf("modctl/%s", version.GitVersion))
+
 	repository.Client = &auth.Client{
 		Cache:      auth.NewCache(),
 		Credential: credentials.Credential(credStore),
 		Client:     httpClient,
+		Header:     header,
 	}
 
 	repository.PlainHTTP = client.plainHTTP


### PR DESCRIPTION
This pull request introduces a new custom `User-Agent` header to all remote registry requests made by the backend client. This helps identify requests originating from `modctl` and can be useful for debugging, analytics, or registry-side filtering. The change also brings in a new dependency on the `version` package to retrieve the current version string.

**Enhancements to remote registry client:**

* Added import of the `version` package to retrieve the current version for the `User-Agent` header in `pkg/backend/remote/client.go`.
* Set a custom `User-Agent` header (`modctl/<version>`) on all outgoing requests by creating an `http.Header` and attaching it to the `auth.Client` in the `New` function.