### PR TITLE
feat(cmd): set raw flag default to true for attach, build, upload

### DIFF
--- a/cmd/attach.go
+++ b/cmd/attach.go
@@ -57,7 +57,7 @@ func init() {
 	flags.BoolVarP(&attachConfig.Force, "force", "f", false, "turning on this flag will force the attach, which will overwrite the layer if it already exists with same filepath")
 	flags.BoolVar(&attachConfig.Nydusify, "nydusify", false, "[EXPERIMENTAL] nydusify the model artifact")
 	flags.MarkHidden("nydusify")
-	flags.BoolVar(&attachConfig.Raw, "raw", false, "turning on this flag will attach model artifact layer in raw format")
+	flags.BoolVar(&attachConfig.Raw, "raw", true, "turning on this flag will attach model artifact layer in raw format")
 	flags.BoolVar(&attachConfig.Config, "config", false, "turning on this flag will overwrite model artifact config layer")
 
 	if err := viper.BindPFlags(flags); err != nil {

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -59,8 +59,7 @@ func init() {
 	flags.MarkHidden("nydusify")
 	flags.StringVar(&buildConfig.SourceURL, "source-url", "", "source URL")
 	flags.StringVar(&buildConfig.SourceRevision, "source-revision", "", "source revision")
-	// TODO: set the raw flag to true by default in future.
-	flags.BoolVar(&buildConfig.Raw, "raw", false, "turning on this flag will build model artifact layers in raw format")
+	flags.BoolVar(&buildConfig.Raw, "raw", true, "turning on this flag will build model artifact layers in raw format")
 	flags.BoolVar(&buildConfig.Reasoning, "reasoning", false, "turning on this flag will mark this model as reasoning model in the config")
 	flags.BoolVar(&buildConfig.NoCreationTime, "no-creation-time", false, "turning on this flag will not set createdAt in the config, which will be helpful for repeated builds")
 

--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -52,7 +52,7 @@ func init() {
 	flags.StringVarP(&uploadConfig.Repo, "repo", "", "", "target model artifact repository name")
 	flags.BoolVarP(&uploadConfig.PlainHTTP, "plain-http", "", false, "turning on this flag will use plain HTTP instead of HTTPS")
 	flags.BoolVarP(&uploadConfig.Insecure, "insecure", "", false, "turning on this flag will disable TLS verification")
-	flags.BoolVar(&uploadConfig.Raw, "raw", false, "turning on this flag will upload model artifact layer in raw format")
+	flags.BoolVar(&uploadConfig.Raw, "raw", true, "turning on this flag will upload model artifact layer in raw format")
 
 	if err := viper.BindPFlags(flags); err != nil {
 		panic(fmt.Errorf("bind cache list flags to viper: %w", err))


### PR DESCRIPTION
This pull request updates the default behavior for the `raw` flag across three CLI commands: `build`, `attach`, and `upload`. The most important change is that the `raw` flag is now enabled by default for these commands, meaning model artifact layers will be processed in raw format unless explicitly disabled.

Default flag behavior updates:

* Changed the default value of the `raw` flag to `true` in the `build` command, so model artifact layers are built in raw format by default (`cmd/build.go`).
* Changed the default value of the `raw` flag to `true` in the `attach` command, so model artifact layers are attached in raw format by default (`cmd/attach.go`).
* Changed the default value of the `raw` flag to `true` in the `upload` command, so model artifact layers are uploaded in raw format by default (`cmd/upload.go`).