### PR TITLE
refactor(xattr): extract xattr operations to dedicated package

### DIFF
--- a/pkg/xattr/xattr.go
+++ b/pkg/xattr/xattr.go
@@ -1,0 +1,61 @@
+/*
+ *     Copyright 2025 The CNAI Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xattr
+
+import (
+	"strings"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	// Prefix for all xattr keys to ensure compatibility across platforms.
+	// Linux requires "user." prefix for user-space xattrs, while macOS allows any key.
+	Prefix = "user."
+
+	// Common xattr keys.
+	KeySize   = "modctl.size"
+	KeyMtime  = "modctl.mtime"
+	KeySha256 = "modctl.sha256"
+)
+
+// Get retrieves an xattr value for a given key.
+func Get(path, key string) ([]byte, error) {
+	var value []byte
+	sz, err := unix.Getxattr(path, key, value)
+	if err != nil {
+		return nil, err
+	}
+
+	value = make([]byte, sz)
+	_, err = unix.Getxattr(path, key, value)
+	if err != nil {
+		return nil, err
+	}
+
+	return value, nil
+}
+
+// Set sets an xattr value for a given key.
+func Set(path, key string, value []byte) error {
+	return unix.Setxattr(path, key, value, 0)
+}
+
+// MakeKey creates a fully-qualified xattr key with the user prefix.
+func MakeKey(parts ...string) string {
+	return Prefix + strings.Join(parts, ".")
+}

--- a/pkg/xattr/xattr_test.go
+++ b/pkg/xattr/xattr_test.go
@@ -1,0 +1,65 @@
+/*
+ *     Copyright 2025 The CNAI Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package xattr
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMakeKey(t *testing.T) {
+	assert.Equal(t, "user.modctl", MakeKey("modctl"))
+	assert.Equal(t, "user.modctl.size", MakeKey("modctl", "size"))
+	assert.Equal(t, "user.modctl.file.digest", MakeKey("modctl", "file", "digest"))
+}
+
+func TestSetAndGet(t *testing.T) {
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "test_file")
+	err := os.WriteFile(filePath, []byte("test"), 0644)
+	require.NoError(t, err)
+
+	// Check if filesystem supports xattrs.
+	key := "user.test"
+	testValue := []byte("test value")
+	if err := Set(filePath, key, testValue); err != nil {
+		t.Skip("Filesystem does not support extended attributes")
+	}
+
+	// Test set and get.
+	value := []byte("hello world")
+	err = Set(filePath, key, value)
+	require.NoError(t, err)
+
+	retrieved, err := Get(filePath, key)
+	require.NoError(t, err)
+	assert.Equal(t, value, retrieved)
+}
+
+func TestGetNonExistent(t *testing.T) {
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "test_file")
+	err := os.WriteFile(filePath, []byte("test"), 0644)
+	require.NoError(t, err)
+
+	_, err = Get(filePath, "user.nonexistent")
+	assert.Error(t, err)
+}


### PR DESCRIPTION
This pull request introduces a new `pkg/xattr` package for managing extended file attributes (xattrs) and refactors the builder and codec logic to leverage xattrs for efficient caching and up-to-date checks. As a result, extraction and build operations can now skip files that are already up-to-date, improving performance and reliability. The changes also propagate this optimization through the extract and pull workflows, and add robust error handling for up-to-date files.

### Xattr caching and utilities

* Added the new `pkg/xattr` package, providing cross-platform helpers for getting, setting, and generating xattr keys, along with unit tests for reliability. [[1]](diffhunk://#diff-8d2d987714d80f8723ba7c6d27b30285064ebf89f663323f47a1dc728b97d19fR1-R66) [[2]](diffhunk://#diff-ac1b16c97d19f1b27f5d5a84aea7e24452ea78a256c560b1082fb7dcc76bf73eR1-R65)

### Builder logic refactor

* Refactored digest and size caching in `pkg/backend/build/builder.go` to use the new `xattr` package, replacing custom xattr helpers and direct syscalls. This centralizes xattr logic and improves maintainability. [[1]](diffhunk://#diff-8ffa00a0129cb498b64f761bd5c4133192873bb004e396b806ebd586ba2bb287L39-R45) [[2]](diffhunk://#diff-8ffa00a0129cb498b64f761bd5c4133192873bb004e396b806ebd586ba2bb287L291-R364) [[3]](diffhunk://#diff-8ffa00a0129cb498b64f761bd5c4133192873bb004e396b806ebd586ba2bb287L445-L493)

### Codec improvements

* Updated the `raw` codec in `pkg/codec/raw.go` to check xattrs for file size and digest before decoding, and to store metadata after writing. If a file is already up-to-date, decoding is skipped and a special error (`ErrAlreadyUpToDate`) is returned. [[1]](diffhunk://#diff-4c12a48b48d9d0895fa3f8e3e221061a135c8768dd5af2e8c6acf7993a26f153R21-R38) [[2]](diffhunk://#diff-4c12a48b48d9d0895fa3f8e3e221061a135c8768dd5af2e8c6acf7993a26f153R57-R120) [[3]](diffhunk://#diff-4c12a48b48d9d0895fa3f8e3e221061a135c8768dd5af2e8c6acf7993a26f153R129-R140) [[4]](diffhunk://#diff-4c12a48b48d9d0895fa3f8e3e221061a135c8768dd5af2e8c6acf7993a26f153R183-R188)

### Extraction and pull workflow optimization

* Modified extraction and pull logic in `pkg/backend/extract.go` and `pkg/backend/pull.go` to handle the "already up-to-date" error gracefully, logging skips and avoiding unnecessary work. [[1]](diffhunk://#diff-e1a825c6b4039fbae050899c58346ac2ad7bcd46f579e16b1b78fc5504848fddR23) [[2]](diffhunk://#diff-e1a825c6b4039fbae050899c58346ac2ad7bcd46f579e16b1b78fc5504848fddL32-R33) [[3]](diffhunk://#diff-e1a825c6b4039fbae050899c58346ac2ad7bcd46f579e16b1b78fc5504848fddR93-R97) [[4]](diffhunk://#diff-e1a825c6b4039fbae050899c58346ac2ad7bcd46f579e16b1b78fc5504848fddL121-R136) [[5]](diffhunk://#diff-f2435c0ad2b72cf7e41c9392804ffc2c7c29981c749a01127d335d228698ac00R22) [[6]](diffhunk://#diff-f2435c0ad2b72cf7e41c9392804ffc2c7c29981c749a01127d335d228698ac00R34) [[7]](diffhunk://#diff-f2435c0ad2b72cf7e41c9392804ffc2c7c29981c749a01127d335d228698ac00L258-R268)

These changes collectively improve the efficiency of model artifact extraction and building by utilizing xattrs for file metadata caching and up-to-date checks.