### PR TITLE
Chore: Pin GitHub Actions to commit SHAs with version comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3    # v6.0.0
         with:
           submodules: recursive
 
       - name: Install Go
-        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00    # v6.0.0
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,15 +28,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3    # v6.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@1b168cd39490f61582a9beae412bb7057a6b2c4e
+        uses: github/codeql-action/init@1b168cd39490f61582a9beae412bb7057a6b2c4e    # v4.31.8
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@1b168cd39490f61582a9beae412bb7057a6b2c4e
+        uses: github/codeql-action/autobuild@1b168cd39490f61582a9beae412bb7057a6b2c4e    # v4.31.8
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@1b168cd39490f61582a9beae412bb7057a6b2c4e
+        uses: github/codeql-action/analyze@1b168cd39490f61582a9beae412bb7057a6b2c4e    # v4.31.8

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,12 +33,12 @@ jobs:
       PACKAGE_DIR: modctl-test-package
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8    # v6.0.1
         with:
           submodules: recursive
 
       - name: Install Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c    # v6.1.0
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum
@@ -49,7 +49,7 @@ jobs:
 
       - name: Cache Package
         id: cache-package
-        uses: actions/cache@v5
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb    # v5.0.1
         with:
           path: ${{ env.PACKAGE_DIR }}
           key: modctl-test-packages
@@ -79,7 +79,7 @@ jobs:
           go build -tags "static system_libgit2 enable_libgit2"
 
       - name: Upload modctl
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f    # v6.0.0
         with:
           name: modctl-artifact
           path: modctl
@@ -90,7 +90,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cache model
-        uses: actions/cache@v5
+        uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb    # v5.0.1
         id: cache-model
         with:
           path: ${{ env.MODEL_DIR }}
@@ -98,7 +98,7 @@ jobs:
 
       - name: Set up Python
         if: steps.cache-model.outputs.cache-hit != 'true'
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548    # v6.1.0
         with:
           python-version: "3.10"
 
@@ -110,7 +110,7 @@ jobs:
           hf download ${{ env.MODEL }} --local-dir ${{ env.MODEL_DIR }}
 
       - name: Upload model
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f    # v6.0.0
         with:
           name: model-artifact
           path: ${{ env.MODEL_DIR }}
@@ -122,12 +122,12 @@ jobs:
     needs: [build-modctl, download-model]
     steps:
       - name: Download modctl artifact
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131    # v7.0.0
         with:
           name: modctl-artifact
           path: modctl
       - name: Download model artifact
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131    # v7.0.0
         with:
           name: model-artifact
           path: ${{ env.MODEL_DIR }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout code
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3    # v6.0.0
         with:
           fetch-depth: '0'
 
@@ -39,7 +39,7 @@ jobs:
             LIBGIT2_SYS_USE_PKG_CONFIG: "1"
 
       - name: Golangci lint
-        uses: golangci/golangci-lint-action@v9.2.0
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20    # v9.2.0
         with:
           version: v2.4
           args: --verbose --timeout=10m

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,12 +27,12 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v6
+      uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8    # v6.0.1
       with:
         fetch-depth: 0
 
     - name: Set up Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c    # v6.1.0
       with:
         go-version: '1.24' # Adjust to your Go version
 
@@ -125,7 +125,7 @@ jobs:
         nfpm pkg --packager rpm --config hack/nfpm.yaml --target dist/modctl-${TAG}-${{ matrix.goos }}-${{ matrix.goarch }}.rpm
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f    # v6.0.0
       with:
         name: modctl-${{ matrix.goos }}-${{ matrix.goarch }}
         path: dist/
@@ -135,7 +135,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Download all artifacts
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131    # v7.0.0
       with:
         path: artifacts
 
@@ -145,7 +145,7 @@ jobs:
           find . -type f \( -name "modctl-*.tar.gz" -o -name "modctl-*.deb" -o -name "modctl-*.rpm" \) -exec shasum -a 256 {} \; > ../checksums.txt
 
     - name: Create draft release
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b    # v2.5.0
       with:
         draft: true
         files: |


### PR DESCRIPTION
- Fixes #361

## Changes Made
- Pin all GitHub Actions to full commit SHAs instead of mutable tags
- Add version comments alongside each SHA for readability
- Updates codeql-analysis.yml, ci.yml, lint.yml, e2e.yml, release.yaml

| File                | Action                         | SHA                                      | Version |
  |---------------------|--------------------------------|------------------------------------------|---------|
  | codeql-analysis.yml | actions/checkout               | 1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 | v6.0.0  |
  |                     | github/codeql-action/init      | 1b168cd39490f61582a9beae412bb7057a6b2c4e | v4.31.8 |
  |                     | github/codeql-action/autobuild | 1b168cd39490f61582a9beae412bb7057a6b2c4e | v4.31.8 |
  |                     | github/codeql-action/analyze   | 1b168cd39490f61582a9beae412bb7057a6b2c4e | v4.31.8 |
  | lint.yml            | actions/checkout               | 1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 | v6.0.0  |
  |                     | golangci/golangci-lint-action  | 1e7e51e771db61008b38414a730f564565cf7c20 | v9.2.0  |
  | ci.yml              | actions/checkout               | 1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 | v6.0.0  |
  |                     | actions/setup-go               | 44694675825211faa026b3c33043df3e48a5fa00 | v6.0.0  |
  | e2e.yml             | actions/checkout               | 8e8c483db84b4bee98b60c0593521ed34d9990e8 | v6.0.1  |
  |                     | actions/setup-go               | 4dc6199c7b1a012772edbd06daecab0f50c9053c | v6.1.0  |
  |                     | actions/cache (×2)             | 9255dc7a253b0ccc959486e2bca901246202afeb | v5.0.1  |
  |                     | actions/upload-artifact (×2)   | b7c566a772e6b6bfb58ed0dc250532a479d7789f | v6.0.0  |
  |                     | actions/setup-python           | 83679a892e2d95755f2dac6acb0bfd1e9ac5d548 | v6.1.0  |
  |                     | actions/download-artifact (×2) | 37930b1c2abaa49bbe596cd826c3c89aef350131 | v7.0.0  |
  | release.yaml        | actions/checkout               | 8e8c483db84b4bee98b60c0593521ed34d9990e8 | v6.0.1  |
  |                     | actions/setup-go               | 4dc6199c7b1a012772edbd06daecab0f50c9053c | v6.1.0  |
  |                     | actions/upload-artifact        | b7c566a772e6b6bfb58ed0dc250532a479d7789f | v6.0.0  |
  |                     | actions/download-artifact      | 37930b1c2abaa49bbe596cd826c3c89aef350131 | v7.0.0  |
  |                     | softprops/action-gh-release    | a06a81a03ee405af7f2048a818ed3f03bbf83c7b | v2.5.0  |