### PR TITLE
feat(attach,upload): add destination-dir flag for custom file paths

### DIFF
--- a/cmd/attach.go
+++ b/cmd/attach.go
@@ -51,6 +51,7 @@ func init() {
 	flags := attachCmd.Flags()
 	flags.StringVarP(&attachConfig.Source, "source", "s", "", "source model artifact name")
 	flags.StringVarP(&attachConfig.Target, "target", "t", "", "target model artifact name")
+	flags.StringVarP(&attachConfig.DestinationDir, "destination-dir", "d", "", "destination directory for the attached file should be specified as a relative path; by default, it will match the original directory of the attachment")
 	flags.BoolVarP(&attachConfig.OutputRemote, "output-remote", "", false, "turning on this flag will output model artifact to remote registry directly")
 	flags.BoolVarP(&attachConfig.PlainHTTP, "plain-http", "", false, "turning on this flag will use plain HTTP instead of HTTPS")
 	flags.BoolVarP(&attachConfig.Insecure, "insecure", "", false, "turning on this flag will disable TLS verification")

--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -53,6 +53,7 @@ func init() {
 	flags.BoolVarP(&uploadConfig.PlainHTTP, "plain-http", "", false, "turning on this flag will use plain HTTP instead of HTTPS")
 	flags.BoolVarP(&uploadConfig.Insecure, "insecure", "", false, "turning on this flag will disable TLS verification")
 	flags.BoolVar(&uploadConfig.Raw, "raw", true, "turning on this flag will upload model artifact layer in raw format")
+	flags.StringVar(&uploadConfig.DestinationDir, "destination-dir", "", "destination directory for the uploaded file should be specified as a relative path; by default, it will match the original directory of the uploaded file")
 
 	if err := viper.BindPFlags(flags); err != nil {
 		panic(fmt.Errorf("bind cache list flags to viper: %w", err))

--- a/pkg/backend/attach_test.go
+++ b/pkg/backend/attach_test.go
@@ -73,7 +73,7 @@ func TestGetProcessor(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.filepath, func(t *testing.T) {
-			proc := b.getProcessor(tt.filepath, false)
+			proc := b.getProcessor("", tt.filepath, false)
 			if tt.wantType == "" {
 				assert.Nil(t, proc)
 			} else {

--- a/pkg/backend/build.go
+++ b/pkg/backend/build.go
@@ -170,7 +170,7 @@ func (b *backend) getProcessors(modelfile modelfile.Modelfile, cfg *config.Build
 		if cfg.Raw {
 			mediaType = modelspec.MediaTypeModelWeightConfigRaw
 		}
-		processors = append(processors, processor.NewModelConfigProcessor(b.store, mediaType, configs))
+		processors = append(processors, processor.NewModelConfigProcessor(b.store, mediaType, configs, ""))
 	}
 
 	if models := modelfile.GetModels(); len(models) > 0 {
@@ -178,7 +178,7 @@ func (b *backend) getProcessors(modelfile modelfile.Modelfile, cfg *config.Build
 		if cfg.Raw {
 			mediaType = modelspec.MediaTypeModelWeightRaw
 		}
-		processors = append(processors, processor.NewModelProcessor(b.store, mediaType, models))
+		processors = append(processors, processor.NewModelProcessor(b.store, mediaType, models, ""))
 	}
 
 	if codes := modelfile.GetCodes(); len(codes) > 0 {
@@ -186,7 +186,7 @@ func (b *backend) getProcessors(modelfile modelfile.Modelfile, cfg *config.Build
 		if cfg.Raw {
 			mediaType = modelspec.MediaTypeModelCodeRaw
 		}
-		processors = append(processors, processor.NewCodeProcessor(b.store, mediaType, codes))
+		processors = append(processors, processor.NewCodeProcessor(b.store, mediaType, codes, ""))
 	}
 
 	if docs := modelfile.GetDocs(); len(docs) > 0 {
@@ -194,7 +194,7 @@ func (b *backend) getProcessors(modelfile modelfile.Modelfile, cfg *config.Build
 		if cfg.Raw {
 			mediaType = modelspec.MediaTypeModelDocRaw
 		}
-		processors = append(processors, processor.NewDocProcessor(b.store, mediaType, docs))
+		processors = append(processors, processor.NewDocProcessor(b.store, mediaType, docs, ""))
 	}
 
 	return processors

--- a/pkg/backend/build/builder.go
+++ b/pkg/backend/build/builder.go
@@ -58,7 +58,7 @@ const (
 // Builder is an interface for building artifacts.
 type Builder interface {
 	// BuildLayer builds the layer blob from the given file path.
-	BuildLayer(ctx context.Context, mediaType, workDir, path string, hooks hooks.Hooks) (ocispec.Descriptor, error)
+	BuildLayer(ctx context.Context, mediaType, workDir, path, destPath string, hooks hooks.Hooks) (ocispec.Descriptor, error)
 
 	// BuildConfig builds the config blob of the artifact.
 	BuildConfig(ctx context.Context, config modelspec.Model, hooks hooks.Hooks) (ocispec.Descriptor, error)
@@ -69,7 +69,7 @@ type Builder interface {
 
 type OutputStrategy interface {
 	// OutputLayer outputs the layer blob to the storage (local or remote).
-	OutputLayer(ctx context.Context, mediaType, relPath, digest string, size int64, reader io.Reader, hooks hooks.Hooks) (ocispec.Descriptor, error)
+	OutputLayer(ctx context.Context, mediaType, relPath, destPath, digest string, size int64, reader io.Reader, hooks hooks.Hooks) (ocispec.Descriptor, error)
 
 	// OutputConfig outputs the config blob to the storage (local or remote).
 	OutputConfig(ctx context.Context, mediaType, digest string, size int64, reader io.Reader, hooks hooks.Hooks) (ocispec.Descriptor, error)
@@ -122,7 +122,7 @@ type abstractBuilder struct {
 	interceptor interceptor.Interceptor
 }
 
-func (ab *abstractBuilder) BuildLayer(ctx context.Context, mediaType, workDir, path string, hooks hooks.Hooks) (ocispec.Descriptor, error) {
+func (ab *abstractBuilder) BuildLayer(ctx context.Context, mediaType, workDir, path, destPath string, hooks hooks.Hooks) (ocispec.Descriptor, error) {
 	info, err := os.Stat(path)
 	if err != nil {
 		return ocispec.Descriptor{}, fmt.Errorf("failed to get file info: %w", err)
@@ -179,7 +179,7 @@ func (ab *abstractBuilder) BuildLayer(ctx context.Context, mediaType, workDir, p
 		}()
 	}
 
-	desc, err := ab.strategy.OutputLayer(ctx, mediaType, relPath, digest, size, reader, hooks)
+	desc, err := ab.strategy.OutputLayer(ctx, mediaType, relPath, destPath, digest, size, reader, hooks)
 	if err != nil {
 		return desc, err
 	}

--- a/pkg/backend/build/builder_test.go
+++ b/pkg/backend/build/builder_test.go
@@ -123,10 +123,10 @@ func (s *BuilderTestSuite) TestBuildLayer() {
 			Size:      100,
 		}
 
-		s.mockOutputStrategy.On("OutputLayer", mock.Anything, "test/media-type.tar", "test-file.txt", mock.AnythingOfType("string"), mock.AnythingOfType("int64"), mock.AnythingOfType("*io.PipeReader"), mock.Anything).
+		s.mockOutputStrategy.On("OutputLayer", mock.Anything, "test/media-type.tar", "test-file.txt", "", mock.AnythingOfType("string"), mock.AnythingOfType("int64"), mock.AnythingOfType("*io.PipeReader"), mock.Anything).
 			Return(expectedDesc, nil)
 
-		desc, err := s.builder.BuildLayer(context.Background(), "test/media-type.tar", s.tempDir, s.tempFile, hooks.NewHooks())
+		desc, err := s.builder.BuildLayer(context.Background(), "test/media-type.tar", s.tempDir, s.tempFile, "", hooks.NewHooks())
 		s.NoError(err)
 		s.Equal(expectedDesc.MediaType, desc.MediaType)
 		s.Equal(expectedDesc.Digest, desc.Digest)
@@ -134,12 +134,12 @@ func (s *BuilderTestSuite) TestBuildLayer() {
 	})
 
 	s.Run("file not found", func() {
-		_, err := s.builder.BuildLayer(context.Background(), "test/media-type.tar", s.tempDir, filepath.Join(s.tempDir, "non-existent.txt"), hooks.NewHooks())
+		_, err := s.builder.BuildLayer(context.Background(), "test/media-type.tar", s.tempDir, filepath.Join(s.tempDir, "non-existent.txt"), "", hooks.NewHooks())
 		s.Error(err)
 	})
 
 	s.Run("directory not supported", func() {
-		_, err := s.builder.BuildLayer(context.Background(), "test/media-type.tar", s.tempDir, s.tempDir, hooks.NewHooks())
+		_, err := s.builder.BuildLayer(context.Background(), "test/media-type.tar", s.tempDir, s.tempDir, "", hooks.NewHooks())
 		s.Error(err)
 		s.True(strings.Contains(err.Error(), "is a directory and not supported yet"))
 	})

--- a/pkg/backend/build/local.go
+++ b/pkg/backend/build/local.go
@@ -46,7 +46,7 @@ type localOutput struct {
 }
 
 // OutputLayer outputs the layer blob to the local storage.
-func (lo *localOutput) OutputLayer(ctx context.Context, mediaType, relPath, digest string, size int64, reader io.Reader, hooks hooks.Hooks) (ocispec.Descriptor, error) {
+func (lo *localOutput) OutputLayer(ctx context.Context, mediaType, relPath, destPath, digest string, size int64, reader io.Reader, hooks hooks.Hooks) (ocispec.Descriptor, error) {
 	reader = hooks.OnStart(relPath, size, reader)
 	digest, size, err := lo.store.PushBlob(ctx, lo.repo, reader, ocispec.Descriptor{})
 	if err != nil {
@@ -54,12 +54,16 @@ func (lo *localOutput) OutputLayer(ctx context.Context, mediaType, relPath, dige
 		return ocispec.Descriptor{}, fmt.Errorf("failed to push blob to storage: %w", err)
 	}
 
+	if destPath == "" {
+		destPath = relPath
+	}
+
 	desc := ocispec.Descriptor{
 		MediaType: mediaType,
 		Digest:    godigest.Digest(digest),
 		Size:      size,
 		Annotations: map[string]string{
-			modelspec.AnnotationFilepath: relPath,
+			modelspec.AnnotationFilepath: destPath,
 		},
 	}
 

--- a/pkg/backend/build/local_test.go
+++ b/pkg/backend/build/local_test.go
@@ -72,7 +72,7 @@ func (s *LocalOutputTestSuite) TestOutputLayer() {
 		s.mockStorage.On("PushBlob", s.ctx, "test-repo", mock.Anything, ocispec.Descriptor{}).
 			Return(expectedDigest, expectedSize, nil).Once()
 
-		desc, err := s.localOutput.OutputLayer(s.ctx, "test/mediatype", "test-file.txt", expectedDigest, expectedSize, reader, hooks.NewHooks())
+		desc, err := s.localOutput.OutputLayer(s.ctx, "test/mediatype", "test-file.txt", "", expectedDigest, expectedSize, reader, hooks.NewHooks())
 
 		s.NoError(err)
 		s.Equal("test/mediatype", desc.MediaType)
@@ -88,7 +88,7 @@ func (s *LocalOutputTestSuite) TestOutputLayer() {
 		s.mockStorage.On("PushBlob", s.ctx, "test-repo", mock.Anything, ocispec.Descriptor{}).
 			Return("", int64(0), errors.New("storage error")).Once()
 
-		_, err := s.localOutput.OutputLayer(s.ctx, "test/mediatype", "/work", "test-file.txt", int64(0), reader, hooks.NewHooks())
+		_, err := s.localOutput.OutputLayer(s.ctx, "test/mediatype", "/work", "test-file.txt", "", int64(0), reader, hooks.NewHooks())
 
 		s.Error(err)
 		s.Contains(err.Error(), "failed to push blob to storage")

--- a/pkg/backend/build/remote.go
+++ b/pkg/backend/build/remote.go
@@ -51,13 +51,17 @@ type remoteOutput struct {
 }
 
 // OutputLayer outputs the layer blob to the remote storage.
-func (ro *remoteOutput) OutputLayer(ctx context.Context, mediaType, relPath, digest string, size int64, reader io.Reader, hooks hooks.Hooks) (ocispec.Descriptor, error) {
+func (ro *remoteOutput) OutputLayer(ctx context.Context, mediaType, relPath, destPath, digest string, size int64, reader io.Reader, hooks hooks.Hooks) (ocispec.Descriptor, error) {
+	if destPath == "" {
+		destPath = relPath
+	}
+
 	desc := ocispec.Descriptor{
 		MediaType: mediaType,
 		Digest:    godigest.Digest(digest),
 		Size:      size,
 		Annotations: map[string]string{
-			modelspec.AnnotationFilepath: relPath,
+			modelspec.AnnotationFilepath: destPath,
 		},
 	}
 

--- a/pkg/backend/processor/code.go
+++ b/pkg/backend/processor/code.go
@@ -30,13 +30,14 @@ const (
 )
 
 // NewCodeProcessor creates a new code processor.
-func NewCodeProcessor(store storage.Storage, mediaType string, patterns []string) Processor {
+func NewCodeProcessor(store storage.Storage, mediaType string, patterns []string, destDir string) Processor {
 	return &codeProcessor{
 		base: &base{
 			name:      codeProcessorName,
 			store:     store,
 			mediaType: mediaType,
 			patterns:  patterns,
+			destDir:   destDir,
 		},
 	}
 }

--- a/pkg/backend/processor/code_test.go
+++ b/pkg/backend/processor/code_test.go
@@ -44,7 +44,7 @@ type codeProcessorSuite struct {
 func (s *codeProcessorSuite) SetupTest() {
 	s.mockStore = &storage.Storage{}
 	s.mockBuilder = &buildmock.Builder{}
-	s.processor = NewCodeProcessor(s.mockStore, modelspec.MediaTypeModelCode, []string{"*.py"})
+	s.processor = NewCodeProcessor(s.mockStore, modelspec.MediaTypeModelCode, []string{"*.py"}, "")
 	// generate test files for prorcess.
 	s.workDir = s.Suite.T().TempDir()
 	if err := os.WriteFile(filepath.Join(s.workDir, "test.py"), []byte(""), 0644); err != nil {
@@ -58,7 +58,7 @@ func (s *codeProcessorSuite) TestName() {
 
 func (s *codeProcessorSuite) TestProcess() {
 	ctx := context.Background()
-	s.mockBuilder.On("BuildLayer", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(ocispec.Descriptor{
+	s.mockBuilder.On("BuildLayer", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(ocispec.Descriptor{
 		Digest: godigest.Digest("sha256:1234567890abcdef"),
 		Size:   int64(1024),
 		Annotations: map[string]string{

--- a/pkg/backend/processor/doc.go
+++ b/pkg/backend/processor/doc.go
@@ -30,13 +30,14 @@ const (
 )
 
 // NewDocProcessor creates a new doc processor.
-func NewDocProcessor(store storage.Storage, mediaType string, patterns []string) Processor {
+func NewDocProcessor(store storage.Storage, mediaType string, patterns []string, destDir string) Processor {
 	return &docProcessor{
 		base: &base{
 			name:      docProcessorName,
 			store:     store,
 			mediaType: mediaType,
 			patterns:  patterns,
+			destDir:   destDir,
 		},
 	}
 }

--- a/pkg/backend/processor/doc_test.go
+++ b/pkg/backend/processor/doc_test.go
@@ -44,7 +44,7 @@ type docProcessorSuite struct {
 func (s *docProcessorSuite) SetupTest() {
 	s.mockStore = &storage.Storage{}
 	s.mockBuilder = &buildmock.Builder{}
-	s.processor = NewDocProcessor(s.mockStore, modelspec.MediaTypeModelDoc, []string{"LICENSE"})
+	s.processor = NewDocProcessor(s.mockStore, modelspec.MediaTypeModelDoc, []string{"LICENSE"}, "")
 	// generate test files for prorcess.
 	s.workDir = s.Suite.T().TempDir()
 	if err := os.WriteFile(filepath.Join(s.workDir, "LICENSE"), []byte(""), 0644); err != nil {
@@ -58,7 +58,7 @@ func (s *docProcessorSuite) TestName() {
 
 func (s *docProcessorSuite) TestProcess() {
 	ctx := context.Background()
-	s.mockBuilder.On("BuildLayer", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(ocispec.Descriptor{
+	s.mockBuilder.On("BuildLayer", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(ocispec.Descriptor{
 		Digest: godigest.Digest("sha256:1234567890abcdef"),
 		Size:   int64(1024),
 		Annotations: map[string]string{

--- a/pkg/backend/processor/model.go
+++ b/pkg/backend/processor/model.go
@@ -30,13 +30,14 @@ const (
 )
 
 // NewModelProcessor creates a new model processor.
-func NewModelProcessor(store storage.Storage, mediaType string, patterns []string) Processor {
+func NewModelProcessor(store storage.Storage, mediaType string, patterns []string, destDir string) Processor {
 	return &modelProcessor{
 		base: &base{
 			name:      modelProcessorName,
 			store:     store,
 			mediaType: mediaType,
 			patterns:  patterns,
+			destDir:   destDir,
 		},
 	}
 }

--- a/pkg/backend/processor/model_config.go
+++ b/pkg/backend/processor/model_config.go
@@ -30,13 +30,14 @@ const (
 )
 
 // NewModelConfigProcessor creates a new model config processor.
-func NewModelConfigProcessor(store storage.Storage, mediaType string, patterns []string) Processor {
+func NewModelConfigProcessor(store storage.Storage, mediaType string, patterns []string, destDir string) Processor {
 	return &modelConfigProcessor{
 		base: &base{
 			name:      modelConfigProcessorName,
 			store:     store,
 			mediaType: mediaType,
 			patterns:  patterns,
+			destDir:   destDir,
 		},
 	}
 }

--- a/pkg/backend/processor/model_config_test.go
+++ b/pkg/backend/processor/model_config_test.go
@@ -44,7 +44,7 @@ type modelConfigProcessorSuite struct {
 func (s *modelConfigProcessorSuite) SetupTest() {
 	s.mockStore = &storage.Storage{}
 	s.mockBuilder = &buildmock.Builder{}
-	s.processor = NewModelConfigProcessor(s.mockStore, modelspec.MediaTypeModelWeightConfig, []string{"config"})
+	s.processor = NewModelConfigProcessor(s.mockStore, modelspec.MediaTypeModelWeightConfig, []string{"config"}, "")
 	// generate test files for prorcess.
 	s.workDir = s.Suite.T().TempDir()
 	if err := os.WriteFile(filepath.Join(s.workDir, "config"), []byte(""), 0644); err != nil {
@@ -58,7 +58,7 @@ func (s *modelConfigProcessorSuite) TestName() {
 
 func (s *modelConfigProcessorSuite) TestProcess() {
 	ctx := context.Background()
-	s.mockBuilder.On("BuildLayer", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(ocispec.Descriptor{
+	s.mockBuilder.On("BuildLayer", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(ocispec.Descriptor{
 		Digest: godigest.Digest("sha256:1234567890abcdef"),
 		Size:   int64(1024),
 		Annotations: map[string]string{

--- a/pkg/backend/processor/model_test.go
+++ b/pkg/backend/processor/model_test.go
@@ -44,7 +44,7 @@ type modelProcessorSuite struct {
 func (s *modelProcessorSuite) SetupTest() {
 	s.mockStore = &storage.Storage{}
 	s.mockBuilder = &buildmock.Builder{}
-	s.processor = NewModelProcessor(s.mockStore, modelspec.MediaTypeModelWeight, []string{"model"})
+	s.processor = NewModelProcessor(s.mockStore, modelspec.MediaTypeModelWeight, []string{"model"}, "")
 	// generate test files for prorcess.
 	s.workDir = s.Suite.T().TempDir()
 	if err := os.WriteFile(filepath.Join(s.workDir, "model"), []byte(""), 0644); err != nil {
@@ -58,7 +58,7 @@ func (s *modelProcessorSuite) TestName() {
 
 func (s *modelProcessorSuite) TestProcess() {
 	ctx := context.Background()
-	s.mockBuilder.On("BuildLayer", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(ocispec.Descriptor{
+	s.mockBuilder.On("BuildLayer", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(ocispec.Descriptor{
 		Digest: godigest.Digest("sha256:1234567890abcdef"),
 		Size:   int64(1024),
 		Annotations: map[string]string{

--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -31,7 +31,7 @@ import (
 // Upload uploads the file to a model artifact repository in advance, but will not push config and manifest.
 func (b *backend) Upload(ctx context.Context, filepath string, cfg *config.Upload) error {
 	logrus.Infof("upload: starting upload operation for file %s [repository: %s]", filepath, cfg.Repo)
-	proc := b.getProcessor(filepath, cfg.Raw)
+	proc := b.getProcessor(cfg.DestinationDir, filepath, cfg.Raw)
 	if proc == nil {
 		return fmt.Errorf("failed to get processor for file %s", filepath)
 	}

--- a/pkg/config/attach.go
+++ b/pkg/config/attach.go
@@ -16,37 +16,49 @@
 
 package config
 
-import "fmt"
+import (
+	"fmt"
+	"path/filepath"
+)
 
 type Attach struct {
-	Source       string
-	Target       string
-	OutputRemote bool
-	PlainHTTP    bool
-	Insecure     bool
-	Nydusify     bool
-	Force        bool
-	Raw          bool
-	Config       bool
+	Source         string
+	Target         string
+	DestinationDir string
+	OutputRemote   bool
+	PlainHTTP      bool
+	Insecure       bool
+	Nydusify       bool
+	Force          bool
+	Raw            bool
+	Config         bool
 }
 
 func NewAttach() *Attach {
 	return &Attach{
-		Source:       "",
-		Target:       "",
-		OutputRemote: false,
-		PlainHTTP:    false,
-		Insecure:     false,
-		Nydusify:     false,
-		Force:        false,
-		Raw:          false,
-		Config:       false,
+		Source:         "",
+		Target:         "",
+		DestinationDir: "",
+		OutputRemote:   false,
+		PlainHTTP:      false,
+		Insecure:       false,
+		Nydusify:       false,
+		Force:          false,
+		Raw:            false,
+		Config:         false,
 	}
 }
 
 func (a *Attach) Validate() error {
 	if a.Source == "" || a.Target == "" {
 		return fmt.Errorf("source and target must be specified")
+	}
+
+	// Check if destination directory is relative path.
+	if a.DestinationDir != "" {
+		if filepath.IsAbs(a.DestinationDir) {
+			return fmt.Errorf("destination directory must be relative path")
+		}
 	}
 
 	if a.Nydusify {

--- a/pkg/config/upload.go
+++ b/pkg/config/upload.go
@@ -16,27 +16,40 @@
 
 package config
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+)
 
 type Upload struct {
-	Repo      string
-	PlainHTTP bool
-	Insecure  bool
-	Raw       bool
+	Repo           string
+	PlainHTTP      bool
+	Insecure       bool
+	Raw            bool
+	DestinationDir string
 }
 
 func NewUpload() *Upload {
 	return &Upload{
-		Repo:      "",
-		PlainHTTP: false,
-		Insecure:  false,
-		Raw:       false,
+		Repo:           "",
+		PlainHTTP:      false,
+		Insecure:       false,
+		Raw:            false,
+		DestinationDir: "",
 	}
 }
 
 func (u *Upload) Validate() error {
 	if u.Repo == "" {
 		return errors.New("repo is required")
+	}
+
+	// Check if destination directory is relative path.
+	if u.DestinationDir != "" {
+		if filepath.IsAbs(u.DestinationDir) {
+			return fmt.Errorf("destination directory must be relative path")
+		}
 	}
 
 	return nil

--- a/test/mocks/backend/build/builder.go
+++ b/test/mocks/backend/build/builder.go
@@ -100,9 +100,9 @@ func (_c *Builder_BuildConfig_Call) RunAndReturn(run func(context.Context, v1.Mo
 	return _c
 }
 
-// BuildLayer provides a mock function with given fields: ctx, mediaType, workDir, path, _a4
-func (_m *Builder) BuildLayer(ctx context.Context, mediaType string, workDir string, path string, _a4 hooks.Hooks) (specs_gov1.Descriptor, error) {
-	ret := _m.Called(ctx, mediaType, workDir, path, _a4)
+// BuildLayer provides a mock function with given fields: ctx, mediaType, workDir, path, destPath, _a5
+func (_m *Builder) BuildLayer(ctx context.Context, mediaType string, workDir string, path string, destPath string, _a5 hooks.Hooks) (specs_gov1.Descriptor, error) {
+	ret := _m.Called(ctx, mediaType, workDir, path, destPath, _a5)
 
 	if len(ret) == 0 {
 		panic("no return value specified for BuildLayer")
@@ -110,17 +110,17 @@ func (_m *Builder) BuildLayer(ctx context.Context, mediaType string, workDir str
 
 	var r0 specs_gov1.Descriptor
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, hooks.Hooks) (specs_gov1.Descriptor, error)); ok {
-		return rf(ctx, mediaType, workDir, path, _a4)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string, hooks.Hooks) (specs_gov1.Descriptor, error)); ok {
+		return rf(ctx, mediaType, workDir, path, destPath, _a5)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, hooks.Hooks) specs_gov1.Descriptor); ok {
-		r0 = rf(ctx, mediaType, workDir, path, _a4)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string, hooks.Hooks) specs_gov1.Descriptor); ok {
+		r0 = rf(ctx, mediaType, workDir, path, destPath, _a5)
 	} else {
 		r0 = ret.Get(0).(specs_gov1.Descriptor)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, hooks.Hooks) error); ok {
-		r1 = rf(ctx, mediaType, workDir, path, _a4)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, string, hooks.Hooks) error); ok {
+		r1 = rf(ctx, mediaType, workDir, path, destPath, _a5)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -138,14 +138,15 @@ type Builder_BuildLayer_Call struct {
 //   - mediaType string
 //   - workDir string
 //   - path string
-//   - _a4 hooks.Hooks
-func (_e *Builder_Expecter) BuildLayer(ctx interface{}, mediaType interface{}, workDir interface{}, path interface{}, _a4 interface{}) *Builder_BuildLayer_Call {
-	return &Builder_BuildLayer_Call{Call: _e.mock.On("BuildLayer", ctx, mediaType, workDir, path, _a4)}
+//   - destPath string
+//   - _a5 hooks.Hooks
+func (_e *Builder_Expecter) BuildLayer(ctx interface{}, mediaType interface{}, workDir interface{}, path interface{}, destPath interface{}, _a5 interface{}) *Builder_BuildLayer_Call {
+	return &Builder_BuildLayer_Call{Call: _e.mock.On("BuildLayer", ctx, mediaType, workDir, path, destPath, _a5)}
 }
 
-func (_c *Builder_BuildLayer_Call) Run(run func(ctx context.Context, mediaType string, workDir string, path string, _a4 hooks.Hooks)) *Builder_BuildLayer_Call {
+func (_c *Builder_BuildLayer_Call) Run(run func(ctx context.Context, mediaType string, workDir string, path string, destPath string, _a5 hooks.Hooks)) *Builder_BuildLayer_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string), args[4].(hooks.Hooks))
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string), args[4].(string), args[5].(hooks.Hooks))
 	})
 	return _c
 }
@@ -155,7 +156,7 @@ func (_c *Builder_BuildLayer_Call) Return(_a0 specs_gov1.Descriptor, _a1 error) 
 	return _c
 }
 
-func (_c *Builder_BuildLayer_Call) RunAndReturn(run func(context.Context, string, string, string, hooks.Hooks) (specs_gov1.Descriptor, error)) *Builder_BuildLayer_Call {
+func (_c *Builder_BuildLayer_Call) RunAndReturn(run func(context.Context, string, string, string, string, hooks.Hooks) (specs_gov1.Descriptor, error)) *Builder_BuildLayer_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/test/mocks/backend/build/output_strategy.go
+++ b/test/mocks/backend/build/output_strategy.go
@@ -103,9 +103,9 @@ func (_c *OutputStrategy_OutputConfig_Call) RunAndReturn(run func(context.Contex
 	return _c
 }
 
-// OutputLayer provides a mock function with given fields: ctx, mediaType, relPath, digest, size, reader, _a6
-func (_m *OutputStrategy) OutputLayer(ctx context.Context, mediaType string, relPath string, digest string, size int64, reader io.Reader, _a6 hooks.Hooks) (v1.Descriptor, error) {
-	ret := _m.Called(ctx, mediaType, relPath, digest, size, reader, _a6)
+// OutputLayer provides a mock function with given fields: ctx, mediaType, relPath, destPath, digest, size, reader, _a7
+func (_m *OutputStrategy) OutputLayer(ctx context.Context, mediaType string, relPath string, destPath string, digest string, size int64, reader io.Reader, _a7 hooks.Hooks) (v1.Descriptor, error) {
+	ret := _m.Called(ctx, mediaType, relPath, destPath, digest, size, reader, _a7)
 
 	if len(ret) == 0 {
 		panic("no return value specified for OutputLayer")
@@ -113,17 +113,17 @@ func (_m *OutputStrategy) OutputLayer(ctx context.Context, mediaType string, rel
 
 	var r0 v1.Descriptor
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, int64, io.Reader, hooks.Hooks) (v1.Descriptor, error)); ok {
-		return rf(ctx, mediaType, relPath, digest, size, reader, _a6)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string, int64, io.Reader, hooks.Hooks) (v1.Descriptor, error)); ok {
+		return rf(ctx, mediaType, relPath, destPath, digest, size, reader, _a7)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, int64, io.Reader, hooks.Hooks) v1.Descriptor); ok {
-		r0 = rf(ctx, mediaType, relPath, digest, size, reader, _a6)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string, int64, io.Reader, hooks.Hooks) v1.Descriptor); ok {
+		r0 = rf(ctx, mediaType, relPath, destPath, digest, size, reader, _a7)
 	} else {
 		r0 = ret.Get(0).(v1.Descriptor)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, int64, io.Reader, hooks.Hooks) error); ok {
-		r1 = rf(ctx, mediaType, relPath, digest, size, reader, _a6)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, string, int64, io.Reader, hooks.Hooks) error); ok {
+		r1 = rf(ctx, mediaType, relPath, destPath, digest, size, reader, _a7)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -140,17 +140,18 @@ type OutputStrategy_OutputLayer_Call struct {
 //   - ctx context.Context
 //   - mediaType string
 //   - relPath string
+//   - destPath string
 //   - digest string
 //   - size int64
 //   - reader io.Reader
-//   - _a6 hooks.Hooks
-func (_e *OutputStrategy_Expecter) OutputLayer(ctx interface{}, mediaType interface{}, relPath interface{}, digest interface{}, size interface{}, reader interface{}, _a6 interface{}) *OutputStrategy_OutputLayer_Call {
-	return &OutputStrategy_OutputLayer_Call{Call: _e.mock.On("OutputLayer", ctx, mediaType, relPath, digest, size, reader, _a6)}
+//   - _a7 hooks.Hooks
+func (_e *OutputStrategy_Expecter) OutputLayer(ctx interface{}, mediaType interface{}, relPath interface{}, destPath interface{}, digest interface{}, size interface{}, reader interface{}, _a7 interface{}) *OutputStrategy_OutputLayer_Call {
+	return &OutputStrategy_OutputLayer_Call{Call: _e.mock.On("OutputLayer", ctx, mediaType, relPath, destPath, digest, size, reader, _a7)}
 }
 
-func (_c *OutputStrategy_OutputLayer_Call) Run(run func(ctx context.Context, mediaType string, relPath string, digest string, size int64, reader io.Reader, _a6 hooks.Hooks)) *OutputStrategy_OutputLayer_Call {
+func (_c *OutputStrategy_OutputLayer_Call) Run(run func(ctx context.Context, mediaType string, relPath string, destPath string, digest string, size int64, reader io.Reader, _a7 hooks.Hooks)) *OutputStrategy_OutputLayer_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string), args[4].(int64), args[5].(io.Reader), args[6].(hooks.Hooks))
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string), args[4].(string), args[5].(int64), args[6].(io.Reader), args[7].(hooks.Hooks))
 	})
 	return _c
 }
@@ -160,7 +161,7 @@ func (_c *OutputStrategy_OutputLayer_Call) Return(_a0 v1.Descriptor, _a1 error) 
 	return _c
 }
 
-func (_c *OutputStrategy_OutputLayer_Call) RunAndReturn(run func(context.Context, string, string, string, int64, io.Reader, hooks.Hooks) (v1.Descriptor, error)) *OutputStrategy_OutputLayer_Call {
+func (_c *OutputStrategy_OutputLayer_Call) RunAndReturn(run func(context.Context, string, string, string, string, int64, io.Reader, hooks.Hooks) (v1.Descriptor, error)) *OutputStrategy_OutputLayer_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
This pull request adds support for specifying a custom destination directory for attached and uploaded files, ensuring that the correct path is annotated and handled throughout the build and attach processes. It introduces a new `--destination-dir` flag to the CLI, propagates this parameter through backend and processor layers, and updates the relevant interfaces, implementations, and tests to support this functionality.

**CLI and Configuration Enhancements:**
- Added a `--destination-dir` flag to both the `attach` and `upload` commands, allowing users to specify a relative destination directory for attached or uploaded files. [[1]](diffhunk://#diff-a7761caf085278622c95504622cb6b5daba0623a2e12032aaf7a26ba4053eb74R54) [[2]](diffhunk://#diff-6833c134d800a5e41f7be71a3764d426179a965ec90addbbc4fb724ae4890c64R56)

**Backend and Processor Integration:**
- Updated processor creation and backend logic to accept and propagate the `destinationDir` parameter, ensuring that the destination path is used for file annotation and processing. [[1]](diffhunk://#diff-25a4006e1f7d4d1bb259002a032f3efe5f4b4dad94b8b3a2fccac02214301559R25) [[2]](diffhunk://#diff-25a4006e1f7d4d1bb259002a032f3efe5f4b4dad94b8b3a2fccac02214301559L77-R78) [[3]](diffhunk://#diff-25a4006e1f7d4d1bb259002a032f3efe5f4b4dad94b8b3a2fccac02214301559R92-R105) [[4]](diffhunk://#diff-25a4006e1f7d4d1bb259002a032f3efe5f4b4dad94b8b3a2fccac02214301559L302-R338) [[5]](diffhunk://#diff-d6967c304021925580fe39f08821dc9e301bcc02a119e188d723e6939f170a5cL173-R197) [[6]](diffhunk://#diff-481a7aea582e1af9469ef2aaa47876a5920678c2c124fdb6eeef24bba9258011R51-R54) [[7]](diffhunk://#diff-481a7aea582e1af9469ef2aaa47876a5920678c2c124fdb6eeef24bba9258011L143-R152) [[8]](diffhunk://#diff-f9966d895dcfe2a13ff7f7b737a756145b42f79e23c811bfbc315dff2d9592bbL33-R40) [[9]](diffhunk://#diff-ea950dfa13579b573d4c8a14a8f1f2ab7be681ac85695f06f17cb86615acdde9L33-R40)

**Build and Output Strategy Updates:**
- Modified the `Builder` and `OutputStrategy` interfaces, as well as their concrete implementations, to accept the destination path and use it for file annotations, ensuring correct metadata in both local and remote outputs. [[1]](diffhunk://#diff-8ffa00a0129cb498b64f761bd5c4133192873bb004e396b806ebd586ba2bb287L61-R61) [[2]](diffhunk://#diff-8ffa00a0129cb498b64f761bd5c4133192873bb004e396b806ebd586ba2bb287L72-R72) [[3]](diffhunk://#diff-8ffa00a0129cb498b64f761bd5c4133192873bb004e396b806ebd586ba2bb287L125-R125) [[4]](diffhunk://#diff-8ffa00a0129cb498b64f761bd5c4133192873bb004e396b806ebd586ba2bb287L182-R182) [[5]](diffhunk://#diff-2a4f1cba53c532d8649ec9b54ecc1acaaae2dda9e0a77d6caf39bf41549989d1L49-R66) [[6]](diffhunk://#diff-a7407d833322bb1904e4de2f73366bb2ca3639e0aadc0193a5082b5591782362L54-R64)

**Test Adjustments:**
- Updated and extended unit tests to account for the new `destinationDir` parameter and the updated method signatures across the backend, build, and processor packages. [[1]](diffhunk://#diff-51e6233079b9908beda48c81a6609e3cec11d80bac7d910f64295ad07f1b3293L76-R76) [[2]](diffhunk://#diff-f52d8374baab56fbd0084244940a313fe50568c31938534a4eed5f2526a266b8L126-R142) [[3]](diffhunk://#diff-9ee665bb75d97827345da43662f1fb89bb14d34fcaf019d9802e919ba353cf5dL75-R75) [[4]](diffhunk://#diff-9ee665bb75d97827345da43662f1fb89bb14d34fcaf019d9802e919ba353cf5dL91-R91) [[5]](diffhunk://#diff-573e98a4ebd989ac38d186e81e39d54f7b28c6a14dc40578f9e012ccfdb8ec72L47-R47) [[6]](diffhunk://#diff-573e98a4ebd989ac38d186e81e39d54f7b28c6a14dc40578f9e012ccfdb8ec72L61-R61) [[7]](diffhunk://#diff-0a53c929ec9c68d7cb47650fa000bb29f2b958596dbd39ef87a778483600ab6fL47-R47)