### PR TITLE
ci(workflows): update macOS runner versions for release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
             runner: ubuntu-24.04-arm
           - goos: darwin
             goarch: amd64
-            runner: macos-13
+            runner: macos-15-intel
           - goos: darwin
             goarch: arm64
             runner: macos-latest


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to use a newer macOS runner for building Darwin AMD64 binaries.

* Workflow configuration update:
  * [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL21-R21): Changed the runner for `goos: darwin`, `goarch: amd64` from `macos-13` to `macos-15-intel` to ensure builds run on the latest supported macOS environment.