### PR TITLE
Add Feature(build): auto-generate Modelfile and add --regenerate flag

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -19,12 +19,17 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
 	"github.com/modelpack/modctl/pkg/backend"
 	"github.com/modelpack/modctl/pkg/config"
+
+	configmodelfile "github.com/modelpack/modctl/pkg/config/modelfile"
+	modelfilegen "github.com/modelpack/modctl/pkg/modelfile"
 )
 
 var buildConfig = config.NewBuild()
@@ -62,24 +67,71 @@ func init() {
 	flags.BoolVar(&buildConfig.Raw, "raw", true, "turning on this flag will build model artifact layers in raw format")
 	flags.BoolVar(&buildConfig.Reasoning, "reasoning", false, "turning on this flag will mark this model as reasoning model in the config")
 	flags.BoolVar(&buildConfig.NoCreationTime, "no-creation-time", false, "turning on this flag will not set createdAt in the config, which will be helpful for repeated builds")
+	flags.BoolVar(&buildConfig.Regenerate, "regenerate", false, "force regenerate Modelfile before building")
 
 	if err := viper.BindPFlags(flags); err != nil {
 		panic(fmt.Errorf("bind cache list flags to viper: %w", err))
 	}
+
 }
 
-// runBuild runs the build modctl.
 func runBuild(ctx context.Context, workDir string) error {
+
+	// Determine modelfile path
+	modelfilePath := buildConfig.Modelfile
+	if modelfilePath == "" {
+		modelfilePath = filepath.Join(workDir, configmodelfile.DefaultModelfileName)
+	} else if !filepath.IsAbs(modelfilePath) {
+		modelfilePath = filepath.Join(workDir, modelfilePath)
+	}
+
+	shouldGenerate := buildConfig.Regenerate
+
+	if shouldGenerate {
+		fmt.Println("Regenerate flag detected. Regenerating Modelfile...")
+	} else {
+		_, err := os.Stat(modelfilePath)
+		if os.IsNotExist(err) {
+			fmt.Println("No Modelfile found. Generating automatically...")
+			shouldGenerate = true
+		} else if err != nil {
+			return fmt.Errorf("error checking Modelfile at %s: %w", modelfilePath, err)
+		}
+	}
+
+	if shouldGenerate {
+		genConfig := configmodelfile.NewGenerateConfig()
+
+		absWorkDir, err := filepath.Abs(workDir)
+		if err != nil {
+			return fmt.Errorf("failed to resolve workspace path: %w", err)
+		}
+
+		genConfig.Workspace = absWorkDir
+		genConfig.Overwrite = true
+
+		mf, err := modelfilegen.NewModelfileByWorkspace(genConfig.Workspace, genConfig)
+		if err != nil {
+			return fmt.Errorf("failed to auto-generate modelfile: %w", err)
+		}
+
+		content := mf.Content()
+		if err := os.WriteFile(modelfilePath, content, 0644); err != nil {
+			return fmt.Errorf("failed to write modelfile: %w", err)
+		}
+
+		fmt.Printf("Successfully generated %s\n", modelfilePath)
+	}
+
 	b, err := backend.New(rootConfig.StoargeDir)
 	if err != nil {
 		return err
 	}
 
-	if err := b.Build(ctx, buildConfig.Modelfile, workDir, buildConfig.Target, buildConfig); err != nil {
+	if err := b.Build(ctx, modelfilePath, workDir, buildConfig.Target, buildConfig); err != nil {
 		return err
 	}
 
 	fmt.Printf("Successfully built model artifact: %s\n", buildConfig.Target)
-
 	return nil
 }

--- a/pkg/config/build.go
+++ b/pkg/config/build.go
@@ -36,6 +36,7 @@ type Build struct {
 	Raw            bool
 	Reasoning      bool
 	NoCreationTime bool
+	Regenerate     bool
 }
 
 func NewBuild() *Build {
@@ -52,6 +53,7 @@ func NewBuild() *Build {
 		Raw:            false,
 		Reasoning:      false,
 		NoCreationTime: false,
+		Regenerate:     false,
 	}
 }
 


### PR DESCRIPTION
This PR simplifies the modctl build workflow.

Now, if a Modelfile is missing, it will be generated automatically during build.
A new --regenerate flag is added to force regeneration before building.

Fixes #362 

### What changed

build auto-generates Modelfile if not found

Added --regenerate flag

Existing behavior will be unchanged if a Modelfile already exists

### Tested

1) Build without Modelfile is working
<img width="1039" height="400" alt="Screenshot 2026-02-11 at 6 07 06 PM" src="https://github.com/user-attachments/assets/8d361ffa-7a6f-467f-888a-94b6831c41c1" />

2) Build with existing Modelfile is working
<img width="1046" height="361" alt="Screenshot 2026-02-11 at 6 07 28 PM" src="https://github.com/user-attachments/assets/0adc6cc9-0e1d-49cc-8541-fc47fa56cee8" />

3) Build with --regenerate is working
<img width="1037" height="370" alt="Screenshot 2026-02-11 at 6 07 50 PM" src="https://github.com/user-attachments/assets/104c8ac5-f885-41a0-9cf4-128b3f104623" />
