### PR TITLE
feat: add --include flag to modelfile generate

### DIFF
--- a/cmd/modelfile/generate.go
+++ b/cmd/modelfile/generate.go
@@ -112,6 +112,10 @@ func init() {
 	flags.StringVarP(&generateConfig.Provider, "provider", "p", "", "explicitly specify the provider for short-form URLs (huggingface, modelscope)")
 	flags.StringVar(&generateConfig.DownloadDir, "download-dir", "", "custom directory for downloading models (default: system temp directory)")
 	flags.StringArrayVar(&generateConfig.ExcludePatterns, "exclude", []string{}, "specify glob patterns to exclude files/directories (e.g. *.log, checkpoints/*)")
+	flags.StringArrayVar(&generateConfig.IncludePatterns, "include", []string{},
+		"glob patterns to include files/directories that are normally skipped (e.g. hidden files).\n"+
+			"Uses doublestar syntax (*, **, ?, [...], {a,b}), matching against relative paths from workspace root.\n"+
+			"Note: broad patterns like **/.*  may include large directories (.git) or sensitive files (.env)")
 
 	// Mark the ignore-unrecognized-file-types flag as deprecated and hidden
 	flags.MarkDeprecated("ignore-unrecognized-file-types", "this flag will be removed in the next release")

--- a/cmd/modelfile/generate.go
+++ b/cmd/modelfile/generate.go
@@ -64,7 +64,16 @@ Full URLs with domain names will auto-detect the provider.`,
   modctl modelfile generate ./my-model-dir --output ./output/modelfile.yaml
 
   # Generate with metadata overrides
-  modctl modelfile generate ./my-model-dir --name my-custom-model --family llama3`,
+  modctl modelfile generate ./my-model-dir --name my-custom-model --family llama3
+
+  # Include hidden files at any depth
+  modctl modelfile generate ./my-model-dir --include "**/.*"
+
+  # Include a specific hidden directory
+  modctl modelfile generate ./my-model-dir --include ".weights/**"
+
+  # Include hidden files but exclude sensitive ones
+  modctl modelfile generate ./my-model-dir --include "**/.*" --exclude "**/.env"`,
 	Args:              cobra.MaximumNArgs(1),
 	DisableAutoGenTag: true,
 	SilenceUsage:      true,

--- a/pkg/config/modelfile/modelfile.go
+++ b/pkg/config/modelfile/modelfile.go
@@ -43,6 +43,7 @@ type GenerateConfig struct {
 	Provider                    string // Explicit provider for short-form URLs (e.g., "huggingface", "modelscope")
 	DownloadDir                 string // Custom directory for downloading models (optional)
 	ExcludePatterns             []string
+	IncludePatterns             []string
 }
 
 func NewGenerateConfig() *GenerateConfig {
@@ -63,6 +64,7 @@ func NewGenerateConfig() *GenerateConfig {
 		Provider:                    "",
 		DownloadDir:                 "",
 		ExcludePatterns:             []string{},
+		IncludePatterns:             []string{},
 	}
 }
 

--- a/pkg/modelfile/constants.go
+++ b/pkg/modelfile/constants.go
@@ -65,12 +65,12 @@ var (
 		// PyTorch formats.
 		"*.bin",   // General binary format
 		"*.bin.*", // Sharded binary files (e.g., model.bin.1)
-		"*.pt",  // PyTorch model
-		"*.pth", // PyTorch model (alternative extension)
-		"*.mar", // PyTorch Model Archive
-		"*.pte", // PyTorch ExecuTorch format
-		"*.pt2", // PyTorch 2.0 export format
-		"*.ptl", // PyTorch Mobile format
+		"*.pt",    // PyTorch model
+		"*.pth",   // PyTorch model (alternative extension)
+		"*.mar",   // PyTorch Model Archive
+		"*.pte",   // PyTorch ExecuTorch format
+		"*.pt2",   // PyTorch 2.0 export format
+		"*.ptl",   // PyTorch Mobile format
 
 		// TensorFlow formats.
 		"*.tflite", // TensorFlow Lite
@@ -85,16 +85,16 @@ var (
 		// GGML formats.
 		"*.gguf",   // GGML Universal Format
 		"*.gguf.*", // Partitioned GGUF files
-		"*.ggml", // GGML format (legacy)
-		"*.ggmf", // GGMF format (deprecated)
-		"*.ggjt", // GGJT format (deprecated)
-		"*.q4_0", // GGML Q4_0 quantization
-		"*.q4_1", // GGML Q4_1 quantization
-		"*.q5_0", // GGML Q5_0 quantization
-		"*.q5_1", // GGML Q5_1 quantization
-		"*.q8_0", // GGML Q8_0 quantization
-		"*.f16",  // GGML F16 format
-		"*.f32",  // GGML F32 format
+		"*.ggml",   // GGML format (legacy)
+		"*.ggmf",   // GGMF format (deprecated)
+		"*.ggjt",   // GGJT format (deprecated)
+		"*.q4_0",   // GGML Q4_0 quantization
+		"*.q4_1",   // GGML Q4_1 quantization
+		"*.q5_0",   // GGML Q5_0 quantization
+		"*.q5_1",   // GGML Q5_1 quantization
+		"*.q8_0",   // GGML Q8_0 quantization
+		"*.f16",    // GGML F16 format
+		"*.f32",    // GGML F32 format
 
 		// checkpoint formats.
 		"*.ckpt",       // Checkpoint format
@@ -109,37 +109,37 @@ var (
 		"*.vocab",     // Vocabulary files (when binary)
 
 		// Other ML frameworks.
-		"*.ot",         // OpenVINO format
-		"*.engine",     // TensorRT format
-		"*.trt",        // TensorRT format (alternative extension)
-		"*.onnx",       // Open Neural Network Exchange format
-		"*.msgpack",    // MessagePack serialization
-		"*.model",      // Some NLP frameworks
-		"*.pkl",        // Pickle format
-		"*.pickle",     // Pickle format (alternative extension)
-		"*.keras",      // Keras native format
-		"*.joblib",     // Joblib serialization (scikit-learn)
-		"*.npy",        // NumPy array format
-		"*.npz",        // NumPy compressed archive
-		"*.nc",         // NetCDF format
-		"*.mlmodel",    // Apple Core ML format
-		"*.coreml",     // Apple Core ML format (alternative)
-		"*.mleap",      // MLeap format (Spark ML)
-		"*.surml",      // SurrealML format
-		"*.llamafile",  // Llamafile format
+		"*.ot",          // OpenVINO format
+		"*.engine",      // TensorRT format
+		"*.trt",         // TensorRT format (alternative extension)
+		"*.onnx",        // Open Neural Network Exchange format
+		"*.msgpack",     // MessagePack serialization
+		"*.model",       // Some NLP frameworks
+		"*.pkl",         // Pickle format
+		"*.pickle",      // Pickle format (alternative extension)
+		"*.keras",       // Keras native format
+		"*.joblib",      // Joblib serialization (scikit-learn)
+		"*.npy",         // NumPy array format
+		"*.npz",         // NumPy compressed archive
+		"*.nc",          // NetCDF format
+		"*.mlmodel",     // Apple Core ML format
+		"*.coreml",      // Apple Core ML format (alternative)
+		"*.mleap",       // MLeap format (Spark ML)
+		"*.surml",       // SurrealML format
+		"*.llamafile",   // Llamafile format
 		"*.llamafile.*", // Llamafile variants
-		"*.caffemodel", // Caffe model format
-		"*.prototxt",   // Caffe model definition
-		"*.dlc",        // Qualcomm Deep Learning Container
-		"*.circle",     // Samsung Circle format
-		"*.nb",         // Neural Network Binary format
+		"*.caffemodel",  // Caffe model format
+		"*.prototxt",    // Caffe model definition
+		"*.dlc",         // Qualcomm Deep Learning Container
+		"*.circle",      // Samsung Circle format
+		"*.nb",          // Neural Network Binary format
 
 		// Data and dataset formats.
-		"*.arrow",      // Apache Arrow columnar format
-		"*.parquet",    // Apache Parquet columnar format
-		"*.ftz",        // FastText compressed model
-		"*.ark",        // Kaldi ark format (speech/audio models)
-		"*.db",         // Database files (LMDB, etc.)
+		"*.arrow",   // Apache Arrow columnar format
+		"*.parquet", // Apache Parquet columnar format
+		"*.ftz",     // FastText compressed model
+		"*.ark",     // Kaldi ark format (speech/audio models)
+		"*.db",      // Database files (LMDB, etc.)
 	}
 
 	// Code file patterns - supported script and notebook files.

--- a/pkg/modelfile/modelfile.go
+++ b/pkg/modelfile/modelfile.go
@@ -258,7 +258,7 @@ func (mf *modelfile) generateByWorkspace(config *configmodelfile.GenerateConfig)
 	var totalSize int64
 
 	// Initialize exclude patterns
-	filter, err := NewPathFilter(config.ExcludePatterns...)
+	filter, err := NewPathFilter(config.ExcludePatterns, config.IncludePatterns)
 	if err != nil {
 		return err
 	}

--- a/pkg/modelfile/modelfile.go
+++ b/pkg/modelfile/modelfile.go
@@ -277,12 +277,32 @@ func (mf *modelfile) generateByWorkspace(config *configmodelfile.GenerateConfig)
 			return err
 		}
 
-		// Skip hidden, skippable, and excluded files/directories.
-		if isSkippable(filename) || filter.Match(relPath) {
+		// Directory exclude is absolute — cannot be reversed by --include.
+		if info.IsDir() && filter.Match(relPath) {
+			return filepath.SkipDir
+		}
+
+		// Check skipPatterns — include can rescue skippable entries.
+		if isSkippable(filename) {
+			if info.IsDir() {
+				if filter.ShouldDescend(relPath) {
+					// Rescued by --include, enter directory
+				} else {
+					return filepath.SkipDir
+				}
+			} else {
+				if !filter.MatchInclude(relPath) {
+					return nil
+				}
+				// Rescued file still goes through exclude check below
+			}
+		}
+
+		// Exclude check for non-skippable files (and include-rescued files).
+		if filter.Match(relPath) {
 			if info.IsDir() {
 				return filepath.SkipDir
 			}
-
 			return nil
 		}
 

--- a/pkg/modelfile/modelfile_test.go
+++ b/pkg/modelfile/modelfile_test.go
@@ -679,13 +679,13 @@ func TestNewModelfileByWorkspace(t *testing.T) {
 		{
 			name: "include all hidden files with recursive pattern",
 			setupFiles: map[string]string{
-				"config.json":                 "",
-				"model.bin":                   "",
-				".hidden_config.json":         "",
-				".hidden_dir/model.bin":       "",
-				".hidden_dir/.nested.py":      "",
-				"normal_dir/.hidden_code.py":  "",
-				"normal_dir/visible.py":       "",
+				"config.json":                "",
+				"model.bin":                  "",
+				".hidden_config.json":        "",
+				".hidden_dir/model.bin":      "",
+				".hidden_dir/.nested.py":     "",
+				"normal_dir/.hidden_code.py": "",
+				"normal_dir/visible.py":      "",
 			},
 			setupDirs: []string{
 				".hidden_dir",
@@ -750,10 +750,10 @@ func TestNewModelfileByWorkspace(t *testing.T) {
 		{
 			name: "no include patterns regression",
 			setupFiles: map[string]string{
-				"config.json":        "",
-				"model.bin":          "",
-				".hidden_file":       "",
-				".hidden_dir/x.py":   "",
+				"config.json":      "",
+				"model.bin":        "",
+				".hidden_file":     "",
+				".hidden_dir/x.py": "",
 			},
 			setupDirs: []string{
 				".hidden_dir",

--- a/pkg/modelfile/modelfile_test.go
+++ b/pkg/modelfile/modelfile_test.go
@@ -676,6 +676,141 @@ func TestNewModelfileByWorkspace(t *testing.T) {
 			expectCodes:   []string{"valid_dir/model.py"},
 			expectName:    "skip-test",
 		},
+		{
+			name: "include all hidden files with recursive pattern",
+			setupFiles: map[string]string{
+				"config.json":                 "",
+				"model.bin":                   "",
+				".hidden_config.json":         "",
+				".hidden_dir/model.bin":       "",
+				".hidden_dir/.nested.py":      "",
+				"normal_dir/.hidden_code.py":  "",
+				"normal_dir/visible.py":       "",
+			},
+			setupDirs: []string{
+				".hidden_dir",
+				"normal_dir",
+			},
+			config: &configmodelfile.GenerateConfig{
+				Name:            "include-all-hidden",
+				IncludePatterns: []string{"**/.*"},
+			},
+			expectError:   false,
+			expectConfigs: []string{"config.json", ".hidden_config.json"},
+			expectModels:  []string{"model.bin", ".hidden_dir/model.bin"},
+			expectCodes:   []string{".hidden_dir/.nested.py", "normal_dir/.hidden_code.py", "normal_dir/visible.py"},
+			expectName:    "include-all-hidden",
+		},
+		{
+			name: "include specific hidden directory",
+			setupFiles: map[string]string{
+				"config.json":        "",
+				"model.bin":          "",
+				".weights/extra.bin": "",
+				".weights/data.bin":  "",
+				".other/secret.py":   "",
+			},
+			setupDirs: []string{
+				".weights",
+				".other",
+			},
+			config: &configmodelfile.GenerateConfig{
+				Name:            "include-weights-dir",
+				IncludePatterns: []string{".weights/**"},
+			},
+			expectError:   false,
+			expectConfigs: []string{"config.json"},
+			expectModels:  []string{"model.bin", ".weights/extra.bin", ".weights/data.bin"},
+			expectCodes:   []string{},
+			expectName:    "include-weights-dir",
+		},
+		{
+			name: "include with exclude override",
+			setupFiles: map[string]string{
+				"config.json":     "",
+				"model.bin":       "",
+				".hidden.py":      "",
+				".env":            "",
+				"sub/.secret.yml": "",
+			},
+			setupDirs: []string{
+				"sub",
+			},
+			config: &configmodelfile.GenerateConfig{
+				Name:            "include-exclude",
+				IncludePatterns: []string{"**/.*"},
+				ExcludePatterns: []string{"**/.env"},
+			},
+			expectError:   false,
+			expectConfigs: []string{"config.json", "sub/.secret.yml"},
+			expectModels:  []string{"model.bin"},
+			expectCodes:   []string{".hidden.py"},
+			expectName:    "include-exclude",
+		},
+		{
+			name: "no include patterns regression",
+			setupFiles: map[string]string{
+				"config.json":        "",
+				"model.bin":          "",
+				".hidden_file":       "",
+				".hidden_dir/x.py":   "",
+			},
+			setupDirs: []string{
+				".hidden_dir",
+			},
+			config: &configmodelfile.GenerateConfig{
+				Name: "no-include-regression",
+			},
+			expectError:   false,
+			expectConfigs: []string{"config.json"},
+			expectModels:  []string{"model.bin"},
+			expectCodes:   []string{},
+			expectName:    "no-include-regression",
+		},
+		{
+			name: "multiple include patterns",
+			setupFiles: map[string]string{
+				"config.json":           "",
+				"model.bin":             "",
+				".hidden.py":            "",
+				"__pycache__/cache.pyc": "",
+			},
+			setupDirs: []string{
+				"__pycache__",
+			},
+			config: &configmodelfile.GenerateConfig{
+				Name:            "multi-include",
+				IncludePatterns: []string{".*", "**/__pycache__/**"},
+			},
+			expectError:   false,
+			expectConfigs: []string{"config.json"},
+			expectModels:  []string{"model.bin"},
+			expectCodes:   []string{".hidden.py", "__pycache__/cache.pyc"},
+			expectName:    "multi-include",
+		},
+		{
+			name: "skippable dirs not matching include are still skipped",
+			setupFiles: map[string]string{
+				"config.json":        "",
+				"model.bin":          "",
+				".git/objects/pack":  "",
+				".weights/model.bin": "",
+			},
+			setupDirs: []string{
+				".git",
+				".git/objects",
+				".weights",
+			},
+			config: &configmodelfile.GenerateConfig{
+				Name:            "selective-include",
+				IncludePatterns: []string{".weights/**"},
+			},
+			expectError:   false,
+			expectConfigs: []string{"config.json"},
+			expectModels:  []string{"model.bin", ".weights/model.bin"},
+			expectCodes:   []string{},
+			expectName:    "selective-include",
+		},
 	}
 
 	assert := assert.New(t)

--- a/pkg/modelfile/path_filter.go
+++ b/pkg/modelfile/path_filter.go
@@ -4,38 +4,95 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+
+	"github.com/bmatcuk/doublestar/v4"
 )
 
 type PathFilter struct {
-	patterns []string
+	excludePatterns []string
+	includePatterns []string
 }
 
-func NewPathFilter(patterns ...string) (*PathFilter, error) {
-	var cleaned []string
-	for _, p := range patterns {
-		// validate the pattern
-		if _, err := filepath.Match(p, ""); err != nil {
-			return nil, fmt.Errorf("invalid exclude pattern: %q", p)
+func NewPathFilter(excludePatterns []string, includePatterns []string) (*PathFilter, error) {
+	var cleanedExclude []string
+	for _, p := range excludePatterns {
+		if _, err := doublestar.PathMatch(p, ""); err != nil {
+			return nil, fmt.Errorf("invalid exclude pattern %q: %w", p, err)
 		}
-		// since filepath.Walk never returns a path with trailing separator, we need to remove separator from patterns
-		cleaned = append(cleaned, strings.TrimRight(p, string(filepath.Separator)))
+		cleanedExclude = append(cleanedExclude, strings.TrimRight(p, string(filepath.Separator)))
 	}
-	return &PathFilter{patterns: cleaned}, nil
+
+	var cleanedInclude []string
+	for _, p := range includePatterns {
+		if _, err := doublestar.PathMatch(p, ""); err != nil {
+			return nil, fmt.Errorf("invalid include pattern %q: %w", p, err)
+		}
+		cleanedInclude = append(cleanedInclude, strings.TrimRight(p, string(filepath.Separator)))
+	}
+
+	return &PathFilter{
+		excludePatterns: cleanedExclude,
+		includePatterns: cleanedInclude,
+	}, nil
 }
 
+// Match checks if a path matches any exclude pattern.
 func (pf *PathFilter) Match(path string) bool {
-	if len(pf.patterns) == 0 {
+	if len(pf.excludePatterns) == 0 {
 		return false
 	}
 
-	for _, pattern := range pf.patterns {
-		matched, err := filepath.Match(pattern, path)
+	for _, pattern := range pf.excludePatterns {
+		matched, err := doublestar.PathMatch(pattern, path)
 		if err != nil {
-			// The only possible returned error is ErrBadPattern
-			// which we checked when creating the filter
 			return false
 		}
 		if matched {
+			return true
+		}
+	}
+
+	return false
+}
+
+// MatchInclude checks if a relative path matches any include pattern.
+func (pf *PathFilter) MatchInclude(relPath string) bool {
+	if len(pf.includePatterns) == 0 {
+		return false
+	}
+
+	for _, pattern := range pf.includePatterns {
+		matched, err := doublestar.PathMatch(pattern, relPath)
+		if err != nil {
+			return false
+		}
+		if matched {
+			return true
+		}
+	}
+
+	return false
+}
+
+// ShouldDescend checks if a skippable directory should be entered
+// because an include pattern might match files inside it.
+func (pf *PathFilter) ShouldDescend(dirRelPath string) bool {
+	if len(pf.includePatterns) == 0 {
+		return false
+	}
+
+	for _, pattern := range pf.includePatterns {
+		// Direct match: pattern matches the directory itself
+		// e.g., "**/.*" matches ".weights" (** matches zero segments)
+		matched, err := doublestar.PathMatch(pattern, dirRelPath)
+		if err == nil && matched {
+			return true
+		}
+
+		// Prefix match: pattern starts with dirRelPath/
+		// e.g., ".weights/**" starts with ".weights/"
+		prefix := dirRelPath + string(filepath.Separator)
+		if strings.HasPrefix(pattern, prefix) {
 			return true
 		}
 	}

--- a/pkg/modelfile/path_filter_test.go
+++ b/pkg/modelfile/path_filter_test.go
@@ -10,44 +10,62 @@ import (
 
 func TestNewPathFilter(t *testing.T) {
 	testcases := []struct {
-		name        string
-		input       []string
-		expected    []string
-		expectError bool
-		errorMsg    string
+		name             string
+		exclude          []string
+		include          []string
+		expectedExclude  []string
+		expectedInclude  []string
+		expectError      bool
+		errorMsg         string
 	}{
 		{
-			name:     "normal patterns",
-			input:    []string{"*.log", "checkpoint*/"},
-			expected: []string{"*.log", "checkpoint*"},
+			name:            "normal exclude patterns",
+			exclude:         []string{"*.log", "checkpoint*/"},
+			expectedExclude: []string{"*.log", "checkpoint*"},
 		},
 		{
-			name:        "invalid pattern",
-			input:       []string{"*.log", "[invalid"},
+			name:        "invalid exclude pattern",
+			exclude:     []string{"*.log", "[invalid"},
 			expectError: true,
-			errorMsg:    `invalid exclude pattern: "[invalid"`,
+			errorMsg:    `invalid exclude pattern "[invalid"`,
+		},
+		{
+			name:            "valid include patterns",
+			include:         []string{"**/.*", ".weights/**"},
+			expectedInclude: []string{"**/.*", ".weights/**"},
+		},
+		{
+			name:        "invalid include pattern",
+			include:     []string{"[invalid"},
+			expectError: true,
+			errorMsg:    `invalid include pattern "[invalid"`,
 		},
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			filter, err := NewPathFilter(tc.input...)
+			filter, err := NewPathFilter(tc.exclude, tc.include)
 
 			if tc.expectError {
-				require.Error(t, err, "Expected an error for input: %q", tc.input)
+				require.Error(t, err, "Expected an error")
 				assert.Contains(t, err.Error(), tc.errorMsg)
 				assert.Nil(t, filter)
 				return
 			}
 
-			require.NoError(t, err, "Did not expect an error for input: %q", tc.input)
+			require.NoError(t, err)
 			require.NotNil(t, filter)
-			assert.Equal(t, tc.expected, filter.patterns)
+			if tc.expectedExclude != nil {
+				assert.Equal(t, tc.expectedExclude, filter.excludePatterns)
+			}
+			if tc.expectedInclude != nil {
+				assert.Equal(t, tc.expectedInclude, filter.includePatterns)
+			}
 		})
 	}
 }
 
-func TestPathFilter_Matches(t *testing.T) {
+func TestPathFilter_Match(t *testing.T) {
 	testcases := []struct {
 		filterName string
 		patterns   []string
@@ -100,7 +118,7 @@ func TestPathFilter_Matches(t *testing.T) {
 			},
 		},
 		{
-			// Since filepath.Match does not support **, the behavior is the same as Directory_Wildcard_Filter
+			// With doublestar, ** now matches across path separators
 			filterName: "Directory_Double_Asterisk_Filter",
 			patterns:   []string{"build/**"},
 			tests: []struct {
@@ -110,8 +128,22 @@ func TestPathFilter_Matches(t *testing.T) {
 			}{
 				{"matches file directly inside", "build/app", true},
 				{"matches hidden file inside", "build/.config", true},
-				{"does not match the directory itself", "build", false},
-				{"does not match nested files", "build/assets/icon.png", false},
+				{"matches the directory itself with doublestar", "build", true},
+				{"matches nested files with doublestar", "build/assets/icon.png", true},
+			},
+		},
+		{
+			filterName: "Recursive_Glob_Filter",
+			patterns:   []string{"**/*.log"},
+			tests: []struct {
+				desc     string
+				path     string
+				expected bool
+			}{
+				{"matches root level log", "debug.log", true},
+				{"matches nested log", "subdir/debug.log", true},
+				{"matches deeply nested log", "a/b/c/debug.log", true},
+				{"does not match non-log", "main.go", false},
 			},
 		},
 		{
@@ -147,7 +179,7 @@ func TestPathFilter_Matches(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.filterName, func(t *testing.T) {
-			filter, err := NewPathFilter(tc.patterns...)
+			filter, err := NewPathFilter(tc.patterns, nil)
 			require.NoError(t, err, "Filter creation with patterns %q failed", tc.patterns)
 			require.NotNil(t, filter)
 
@@ -159,4 +191,202 @@ func TestPathFilter_Matches(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPathFilter_MatchInclude(t *testing.T) {
+	testcases := []struct {
+		name     string
+		includes []string
+		tests    []struct {
+			desc     string
+			path     string
+			expected bool
+		}
+	}{
+		{
+			name:     "empty include patterns",
+			includes: nil,
+			tests: []struct {
+				desc     string
+				path     string
+				expected bool
+			}{
+				{"any path returns false", "subdir/.hidden", false},
+				{"root hidden returns false", ".hidden", false},
+			},
+		},
+		{
+			name:     "root-only dot pattern",
+			includes: []string{".*"},
+			tests: []struct {
+				desc     string
+				path     string
+				expected bool
+			}{
+				{"matches root hidden file", ".hidden", true},
+				{"matches root .env", ".env", true},
+				{"does not match nested hidden", "subdir/.hidden", false},
+				{"does not match normal file", "normal.txt", false},
+			},
+		},
+		{
+			name:     "recursive dot pattern",
+			includes: []string{"**/.*"},
+			tests: []struct {
+				desc     string
+				path     string
+				expected bool
+			}{
+				{"matches root hidden", ".hidden", true},
+				{"matches nested hidden", "subdir/.hidden", true},
+				{"matches deeply nested", "a/b/.config", true},
+				{"does not match normal", "subdir/normal", false},
+			},
+		},
+		{
+			name:     "specific dir pattern",
+			includes: []string{".weights/**"},
+			tests: []struct {
+				desc     string
+				path     string
+				expected bool
+			}{
+				{"matches file inside", ".weights/model.bin", true},
+				{"matches nested file inside", ".weights/sub/data.bin", true},
+				{"does not match other hidden", ".config/file", false},
+			},
+		},
+		{
+			name:     "brace expansion",
+			includes: []string{".{weights,config}/**"},
+			tests: []struct {
+				desc     string
+				path     string
+				expected bool
+			}{
+				{"matches .weights/x", ".weights/model.bin", true},
+				{"matches .config/y", ".config/settings.json", true},
+				{"does not match .other/z", ".other/file", false},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			filter, err := NewPathFilter(nil, tc.includes)
+			require.NoError(t, err)
+
+			for _, test := range tc.tests {
+				t.Run(test.desc, func(t *testing.T) {
+					result := filter.MatchInclude(test.path)
+					assert.Equal(t, test.expected, result, "Path: %q", test.path)
+				})
+			}
+		})
+	}
+}
+
+func TestPathFilter_ShouldDescend(t *testing.T) {
+	testcases := []struct {
+		name     string
+		includes []string
+		tests    []struct {
+			desc     string
+			dirPath  string
+			expected bool
+		}
+	}{
+		{
+			name:     "no include patterns",
+			includes: nil,
+			tests: []struct {
+				desc     string
+				dirPath  string
+				expected bool
+			}{
+				{"any dir returns false", ".weights", false},
+			},
+		},
+		{
+			name:     "recursive dot pattern enters dot dirs only",
+			includes: []string{"**/.*"},
+			tests: []struct {
+				desc     string
+				dirPath  string
+				expected bool
+			}{
+				{"enters root hidden dir", ".weights", true},
+				{"enters nested hidden dir", "subdir/.hidden", true},
+				{"does not enter __pycache__", "__pycache__", false},
+				{"does not enter normal skippable", "modelfile", false},
+			},
+		},
+		{
+			name:     "pycache pattern enters pycache only",
+			includes: []string{"**/__pycache__/**"},
+			tests: []struct {
+				desc     string
+				dirPath  string
+				expected bool
+			}{
+				{"enters __pycache__", "__pycache__", true},
+				{"enters nested __pycache__", "src/__pycache__", true},
+				{"does not enter hidden dir", ".hidden", false},
+			},
+		},
+		{
+			name:     "prefix match for specific dir",
+			includes: []string{".weights/**"},
+			tests: []struct {
+				desc     string
+				dirPath  string
+				expected bool
+			}{
+				{"enters .weights", ".weights", true},
+				{"does not enter .weird", ".weird", false},
+				{"does not enter .config", ".config", false},
+			},
+		},
+		{
+			name:     "prefix boundary",
+			includes: []string{".weights/*"},
+			tests: []struct {
+				desc     string
+				dirPath  string
+				expected bool
+			}{
+				{"enters .weights", ".weights", true},
+				{"does not enter .weird", ".weird", false},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			filter, err := NewPathFilter(nil, tc.includes)
+			require.NoError(t, err)
+
+			for _, test := range tc.tests {
+				t.Run(test.desc, func(t *testing.T) {
+					result := filter.ShouldDescend(test.dirPath)
+					assert.Equal(t, test.expected, result, "Dir: %q", test.dirPath)
+				})
+			}
+		})
+	}
+}
+
+func TestPathFilter_IncludeExcludeInteraction(t *testing.T) {
+	// File matches both include and exclude → excluded (exclude wins)
+	filter, err := NewPathFilter([]string{"**/.env"}, []string{"**/.*"})
+	require.NoError(t, err)
+
+	// .env matches include pattern **/.*
+	assert.True(t, filter.MatchInclude(".env"))
+	// .env also matches exclude pattern **/.env
+	assert.True(t, filter.Match(".env"))
+
+	// .hidden matches include but not exclude
+	assert.True(t, filter.MatchInclude(".hidden"))
+	assert.False(t, filter.Match(".hidden"))
 }

--- a/pkg/modelfile/path_filter_test.go
+++ b/pkg/modelfile/path_filter_test.go
@@ -10,13 +10,13 @@ import (
 
 func TestNewPathFilter(t *testing.T) {
 	testcases := []struct {
-		name             string
-		exclude          []string
-		include          []string
-		expectedExclude  []string
-		expectedInclude  []string
-		expectError      bool
-		errorMsg         string
+		name            string
+		exclude         []string
+		include         []string
+		expectedExclude []string
+		expectedInclude []string
+		expectError     bool
+		errorMsg        string
 	}{
 		{
 			name:            "normal exclude patterns",


### PR DESCRIPTION
## Summary

- Add `--include` flag to `modctl modelfile generate` that overrides `skipPatterns` (hidden files, `__pycache__`, etc.) using doublestar glob matching
- Migrate `PathFilter` exclude matching from `filepath.Match` to `doublestar.PathMatch` for consistency with `pkg/backend/fetch.go`
- Support `**` recursive glob in both `--include` and `--exclude` patterns

## Changes

- **`pkg/modelfile/path_filter.go`**: Migrate to doublestar, add `MatchInclude()` and `ShouldDescend()` methods
- **`pkg/modelfile/modelfile.go`**: New filter logic — directory exclude is absolute, include rescues skipPatterns, exclude has final say
- **`pkg/config/modelfile/modelfile.go`**: Add `IncludePatterns` field to `GenerateConfig`
- **`cmd/modelfile/generate.go`**: Bind `--include` flag with help text and examples

## Usage

```bash
# Include all hidden files at any depth
modctl modelfile generate ./workspace --include "**/.*"

# Include a specific hidden directory
modctl modelfile generate ./workspace --include ".weights/**"

# Include hidden files but exclude sensitive ones
modctl modelfile generate ./workspace --include "**/.*" --exclude "**/.env"
```

## Filter priority

`--exclude` > `--include` > `skipPatterns`

## Test plan

- [x] PathFilter unit tests: MatchInclude, ShouldDescend, pattern validation, include/exclude interaction
- [x] Integration tests: recursive include, specific dir, include+exclude, regression, multiple patterns, selective entry
- [x] Manual smoke test: verified hidden files appear/disappear correctly
- [x] `go vet` and `gofmt` pass
- [x] All existing tests pass (no regression)