### PR TITLE
fix(backend): close the ReadCloser returned by PullBlob in push

### DIFF
--- a/pkg/backend/push.go
+++ b/pkg/backend/push.go
@@ -186,6 +186,13 @@ func pushIfNotExist(ctx context.Context, pb *internalpb.ProgressBar, prompt stri
 		if err != nil {
 			return err
 		}
+		// The ReadCloser returned by PullBlob was previously never closed on
+		// either path, leaking the underlying file descriptor (or HTTP body)
+		// for every blob we pushed. Close on the distribution implementation
+		// returns an error (#50), which is why we still wrap the reader with
+		// io.NopCloser below, but we DO need to close `content` ourselves.
+		// See #491.
+		defer content.Close()
 
 		reader := pb.Add(prompt, desc.Digest.String(), desc.Size, tracker.WrapReader(content))
 		// resolve issue: https://github.com/modelpack/modctl/issues/50

--- a/pkg/backend/push.go
+++ b/pkg/backend/push.go
@@ -186,12 +186,9 @@ func pushIfNotExist(ctx context.Context, pb *internalpb.ProgressBar, prompt stri
 		if err != nil {
 			return err
 		}
-		// The ReadCloser returned by PullBlob was previously never closed on
-		// either path, leaking the underlying file descriptor (or HTTP body)
-		// for every blob we pushed. Close on the distribution implementation
-		// returns an error (#50), which is why we still wrap the reader with
-		// io.NopCloser below, but we DO need to close `content` ourselves.
-		// See #491.
+		// Ensure the blob content is closed to avoid leaking resources (#491).
+		// We use defer here and io.NopCloser below to work around the distribution
+		// library's Close() implementation which returns a known error (#50).
 		defer content.Close()
 
 		reader := pb.Add(prompt, desc.Digest.String(), desc.Size, tracker.WrapReader(content))


### PR DESCRIPTION
### Problem

`pushIfNotExist` pulls each blob's content from the source storage and
then hands it to `Blobs().Push` wrapped in `io.NopCloser`:

```go
content, err := src.PullBlob(ctx, repo, desc.Digest.String())
if err != nil {
    return err
}

reader := pb.Add(prompt, desc.Digest.String(), desc.Size, content)
if err := dst.Blobs().Push(ctx, desc, io.NopCloser(reader)); err != nil {
    ...
}
```

The `io.NopCloser` is intentional: `Close` on the distribution reader
returns an error (see #50), so we don't let `Push` propagate that error.
But the wrapper also prevents the original `content` from ever being
closed. On both success and error paths, the underlying file descriptor
(or HTTP body) leaks for every blob we push, and `Push` is called once
per object in the image. #491.

### Fix

Add `defer content.Close()` immediately after the nil-error check. The
existing `NopCloser` still prevents `Push` from calling `Close` on its
own, so the workaround for #50 is preserved. `defer` handles both the
success path and every early-return error path.

```diff
  content, err := src.PullBlob(ctx, repo, desc.Digest.String())
  if err != nil {
      return err
  }
+ defer content.Close()

  reader := pb.Add(prompt, desc.Digest.String(), desc.Size, content)
```

Fixes #491