### PR TITLE
fix(backend): short-circuit retry.Do on 401/403 auth errors from the registry

### DIFF
--- a/pkg/backend/retry.go
+++ b/pkg/backend/retry.go
@@ -17,14 +17,33 @@
 package backend
 
 import (
+	"errors"
+	"net/http"
 	"time"
 
 	retry "github.com/avast/retry-go/v4"
+	"oras.land/oras-go/v2/registry/remote/errcode"
 )
+
+// isAuthError reports whether err represents a registry auth failure that
+// cannot be fixed by retrying the same request with the same credentials.
+// Retrying those wastes the user's time on the ~30s+ exponential backoff
+// before the final error surfaces, so callers should short-circuit instead.
+func isAuthError(err error) bool {
+	var respErr *errcode.ErrorResponse
+	if errors.As(err, &respErr) {
+		return respErr.StatusCode == http.StatusUnauthorized ||
+			respErr.StatusCode == http.StatusForbidden
+	}
+	return false
+}
 
 var defaultRetryOpts = []retry.Option{
 	retry.Attempts(6),
 	retry.DelayType(retry.BackOffDelay),
 	retry.Delay(5 * time.Second),
 	retry.MaxDelay(60 * time.Second),
+	// Registry auth errors will not recover on retry; fail fast so the user
+	// sees the real error within seconds instead of 30s+ of silent backoff.
+	retry.RetryIf(func(err error) bool { return !isAuthError(err) }),
 }


### PR DESCRIPTION
## What

`pull` and `push` wrap per-layer processing in `retry.Do(..., defaultRetryOpts...)` (`pkg/backend/pull.go:116-129`, `push.go:92-99`). `defaultRetryOpts` sets 6 attempts with exponential backoff from 5s to 60s but never sets a `RetryIf` predicate, so every error is treated as transient. That includes HTTP 401 / 403 from the registry, which never recover on retry with the same credentials, the user sits through ~30, 60 s of silent backoff before seeing the real "authentication required" error.

Per #494 this is a usability regression: the registry gives an immediate, actionable response, modctl turns it into a long pause.

## Fix

Add a `RetryIf` predicate that unwraps the error chain looking for `oras.land/oras-go/v2/registry/remote/errcode.ErrorResponse` (the typed error oras surfaces when the registry's HTTP response is a protocol-level failure) and returns `false` for `401` / `403`:

```go
func isAuthError(err error) bool {
    var respErr *errcode.ErrorResponse
    if errors.As(err, &respErr) {
        return respErr.StatusCode == http.StatusUnauthorized ||
            respErr.StatusCode == http.StatusForbidden
    }
    return false
}

var defaultRetryOpts = []retry.Option{
    retry.Attempts(6),
    retry.DelayType(retry.BackOffDelay),
    retry.Delay(5 * time.Second),
    retry.MaxDelay(60 * time.Second),
    retry.RetryIf(func(err error) bool { return !isAuthError(err) }),
}
```

- Transient HTTP failures (5xx, network resets, registry rate-limit 429, context-canceled, etc.) still retry exactly as before.
- Only 401/403 short-circuit, so the first auth error reaches the user within seconds instead of after ~30 s of backoff.
- `errors.As` walks the chain, so wrapped errors (`fmt.Errorf("pull: ...: %w", err)` in the caller) still classify correctly.

Fixes #494