### PR TITLE
fix(pb): make disableProgress race-free with sync/atomic.Bool

### DIFF
--- a/internal/pb/pb.go
+++ b/internal/pb/pb.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"os"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	humanize "github.com/dustin/go-humanize"
@@ -30,13 +31,16 @@ import (
 )
 
 var (
-	// disableProgress is the flag to disable progress bar.
-	disableProgress bool
+	// disableProgress is the flag to disable progress bar. Read from the
+	// progress-bar hot path by concurrent pull/push workers while a single
+	// goroutine may flip it via SetDisableProgress, so the access is guarded
+	// by sync/atomic to stay race-free under `go test -race`.
+	disableProgress atomic.Bool
 )
 
 // SetDisableProgress disables the progress bar.
 func SetDisableProgress(disable bool) {
-	disableProgress = disable
+	disableProgress.Store(disable)
 }
 
 // NormalizePrompt normalizes the prompt string.
@@ -85,7 +89,7 @@ func NewProgressBar(writers ...io.Writer) *ProgressBar {
 // Add adds a new progress bar.
 func (p *ProgressBar) Add(prompt, name string, size int64, reader io.Reader) io.Reader {
 	// Return the reader directly if progress is disabled.
-	if disableProgress {
+	if disableProgress.Load() {
 		return reader
 	}
 


### PR DESCRIPTION
## What

`internal/pb/pb.go:33-40` declares a package-level `disableProgress` bool that gets written by `SetDisableProgress(disable bool)` and read from the progress-bar hot path inside `(*ProgressBar).Add`:

```go
var (
    disableProgress bool
)

func SetDisableProgress(disable bool) {
    disableProgress = disable
}

// ... later
if disableProgress {
    return reader
}
```

Multiple concurrent pull/push workers call `Add` from their goroutines while the main goroutine (CLI arg parsing, feature flags, etc.) may still flip `disableProgress`. The access is unsynchronised, so per #493 `go test -race` reports a data race, and the Go memory model leaves the behaviour undefined in practice.

## Fix

Use `sync/atomic.Bool`:

```go
var (
    disableProgress atomic.Bool
)

func SetDisableProgress(disable bool) {
    disableProgress.Store(disable)
}

// ... later
if disableProgress.Load() {
    return reader
}
```

No public-API change — `SetDisableProgress(bool)` keeps the same signature. Callers and tests continue to pass a plain bool; the race-detector reports clean.

Fixes #493