### PR TITLE
[codex] Add Upload missing-file regression test

### DIFF
--- a/pkg/backend/upload_test.go
+++ b/pkg/backend/upload_test.go
@@ -1,0 +1,43 @@
+/*
+ *     Copyright 2025 The CNAI Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package backend
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/modelpack/modctl/pkg/config"
+	mockstore "github.com/modelpack/modctl/test/mocks/storage"
+)
+
+func TestUploadMissingFileReturnsProcessorStatError(t *testing.T) {
+	b := &backend{store: &mockstore.Storage{}}
+	missingFile := filepath.Join(t.TempDir(), "missing.unknown")
+
+	err := b.Upload(context.Background(), missingFile, &config.Upload{
+		Repo: "example.com/acme/model",
+	})
+
+	if assert.Error(t, err) {
+		assert.ErrorContains(t, err, "failed to get processor")
+		assert.ErrorContains(t, err, "failed to stat file")
+		assert.ErrorContains(t, err, missingFile)
+	}
+}


### PR DESCRIPTION
## Summary
- add a focused backend regression test for `Upload` when the input file is missing
- assert `Upload` preserves the `getProcessor` stat failure introduced by #499
- cover a recent behavior change that previously only had helper-level tests

## Why
`#499` changed `Upload` to surface `getProcessor` errors, but the package only tested `getProcessor` directly. This leaves the public `Upload` entrypoint unguarded against regressing back to the older generic error path.

## Validation
- `go test ./pkg/backend -run TestUploadMissingFileReturnsProcessorStatError -count=1`
- `go test ./pkg/backend -count=1`
- red state on `1c9e7ff^`: `go test ./pkg/backend -run TestUploadMissingFileReturnsProcessorStatError -count=1`
