### PR TITLE
[codex] Update diagnostic package copyright headers

### DIFF
--- a/pkg/envinfo/cgroup_linux.go
+++ b/pkg/envinfo/cgroup_linux.go
@@ -1,5 +1,7 @@
+//go:build linux
+
 /*
- *     Copyright 2024 The CNAI Authors
+ *     Copyright 2024 The ModelPack Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,8 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-//go:build linux
 
 package envinfo
 

--- a/pkg/envinfo/cgroup_linux_test.go
+++ b/pkg/envinfo/cgroup_linux_test.go
@@ -1,5 +1,7 @@
+//go:build linux
+
 /*
- *     Copyright 2024 The CNAI Authors
+ *     Copyright 2024 The ModelPack Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,8 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-//go:build linux
 
 package envinfo
 

--- a/pkg/envinfo/cgroup_other.go
+++ b/pkg/envinfo/cgroup_other.go
@@ -1,5 +1,7 @@
+//go:build !linux
+
 /*
- *     Copyright 2024 The CNAI Authors
+ *     Copyright 2024 The ModelPack Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,8 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-//go:build !linux
 
 package envinfo
 

--- a/pkg/envinfo/envinfo.go
+++ b/pkg/envinfo/envinfo.go
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2024 The CNAI Authors
+ *     Copyright 2024 The ModelPack Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/envinfo/envinfo_test.go
+++ b/pkg/envinfo/envinfo_test.go
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2024 The CNAI Authors
+ *     Copyright 2024 The ModelPack Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/iometrics/format.go
+++ b/pkg/iometrics/format.go
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2024 The CNAI Authors
+ *     Copyright 2024 The ModelPack Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/iometrics/reader.go
+++ b/pkg/iometrics/reader.go
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2024 The CNAI Authors
+ *     Copyright 2024 The ModelPack Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/iometrics/tracker.go
+++ b/pkg/iometrics/tracker.go
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2024 The CNAI Authors
+ *     Copyright 2024 The ModelPack Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -112,13 +112,13 @@ func (t *Tracker) Summary() {
 
 	// Log structured fields to log file.
 	logrus.WithFields(logrus.Fields{
-		"operation":            t.operation,
-		"totalBytes":           humanize.IBytes(uint64(totalBytes)),
-		"wallClock":            wallClock.Round(time.Millisecond).String(),
-		"effectiveThroughput":  formatThroughput(totalBytes, wallClock),
-		t.sourceLabel():        sourceThroughput,
-		t.sinkLabel():          sinkThroughput,
-		"bottleneck":           bottleneck,
+		"operation":           t.operation,
+		"totalBytes":          humanize.IBytes(uint64(totalBytes)),
+		"wallClock":           wallClock.Round(time.Millisecond).String(),
+		"effectiveThroughput": formatThroughput(totalBytes, wallClock),
+		t.sourceLabel():       sourceThroughput,
+		t.sinkLabel():         sinkThroughput,
+		"bottleneck":          bottleneck,
 	}).Info("io throughput summary")
 
 	// Print concise summary to terminal.

--- a/pkg/iometrics/tracker_test.go
+++ b/pkg/iometrics/tracker_test.go
@@ -1,5 +1,5 @@
 /*
- *     Copyright 2024 The CNAI Authors
+ *     Copyright 2024 The ModelPack Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary

- Update the missed `pkg/envinfo` and `pkg/iometrics` Go copyright headers from CNAI to ModelPack.
- Run gofmt on the touched files so the repository returns to a gofmt-clean state.

## Why

PR #523 updated existing files before PR #490 added these diagnostic packages, so the new files kept the old CNAI header. The gofmt changes also resolve the formatting drift tracked in #532.

Closes #532.

## Validation

- `grep -RIn "Copyright 2024 The CNAI Authors" --include='*.go' pkg/envinfo pkg/iometrics || true`
- `gofmt -l $(git ls-files '*.go')`
- `GOCACHE=$(mktemp -d /tmp/modctl-pr-gocache2.XXXXXX) go test ./pkg/envinfo ./pkg/iometrics`
- `GOCACHE=$(mktemp -d /tmp/modctl-pr-gocache-all.XXXXXX) go test ./...`
