### PR TITLE
test(build): fix data race in TestBuildLayer under -race

### DIFF
--- a/pkg/backend/build/builder_test.go
+++ b/pkg/backend/build/builder_test.go
@@ -159,8 +159,14 @@ func (s *BuilderTestSuite) TestBuildLayer() {
 		// Use a hand-written strategy instead of the testify mock: BuildLayer
 		// passes OutputLayer a live *io.PipeReader, and the mock's argument
 		// diffing formats it with fmt, racing with the pipe's writer goroutine.
-		strategy := &recordingStrategy{desc: expectedDesc}
+		strategy := &recordingStrategy{
+			OutputStrategy: s.mockOutputStrategy,
+			desc:           expectedDesc,
+		}
 		s.builder.strategy = strategy
+		defer func() {
+			s.builder.strategy = s.mockOutputStrategy
+		}()
 
 		desc, err := s.builder.BuildLayer(context.Background(), "test/media-type.tar", s.tempDir, s.tempFile, "", hooks.NewHooks())
 		s.NoError(err)

--- a/pkg/backend/build/builder_test.go
+++ b/pkg/backend/build/builder_test.go
@@ -115,6 +115,39 @@ func (s *BuilderTestSuite) TestNewBuilder() {
 	}
 }
 
+// recordingStrategy is a hand-written OutputStrategy used by TestBuildLayer.
+//
+// BuildLayer hands OutputLayer a live *io.PipeReader whose background tar
+// writer goroutine is mid-write. The generated testify mock formats every
+// argument with fmt (via mock.Arguments.Diff) when matching the call, which
+// reflects into the pipe's internal state concurrently with that writer -- a
+// data race reported under `go test -race`. This fake reads the reader like
+// the real strategies do, which avoids the reflection and unblocks the writer
+// goroutine.
+type recordingStrategy struct {
+	OutputStrategy // OutputConfig/OutputManifest are unused by this test.
+
+	desc ocispec.Descriptor
+	err  error
+
+	called    bool
+	mediaType string
+	relPath   string
+	destPath  string
+	size      int64
+	gotReader bool
+}
+
+func (r *recordingStrategy) OutputLayer(_ context.Context, mediaType, relPath, destPath, _ string, size int64, reader io.Reader, _ hooks.Hooks) (ocispec.Descriptor, error) {
+	r.called = true
+	r.mediaType, r.relPath, r.destPath, r.size = mediaType, relPath, destPath, size
+	r.gotReader = reader != nil
+	if reader != nil {
+		_, _ = io.Copy(io.Discard, reader)
+	}
+	return r.desc, r.err
+}
+
 func (s *BuilderTestSuite) TestBuildLayer() {
 	s.Run("successful build layer", func() {
 		expectedDesc := ocispec.Descriptor{
@@ -123,11 +156,19 @@ func (s *BuilderTestSuite) TestBuildLayer() {
 			Size:      100,
 		}
 
-		s.mockOutputStrategy.On("OutputLayer", mock.Anything, "test/media-type.tar", "test-file.txt", "", mock.AnythingOfType("string"), mock.AnythingOfType("int64"), mock.AnythingOfType("*io.PipeReader"), mock.Anything).
-			Return(expectedDesc, nil)
+		// Use a hand-written strategy instead of the testify mock: BuildLayer
+		// passes OutputLayer a live *io.PipeReader, and the mock's argument
+		// diffing formats it with fmt, racing with the pipe's writer goroutine.
+		strategy := &recordingStrategy{desc: expectedDesc}
+		s.builder.strategy = strategy
 
 		desc, err := s.builder.BuildLayer(context.Background(), "test/media-type.tar", s.tempDir, s.tempFile, "", hooks.NewHooks())
 		s.NoError(err)
+		s.True(strategy.called)
+		s.Equal("test/media-type.tar", strategy.mediaType)
+		s.Equal("test-file.txt", strategy.relPath)
+		s.Equal("", strategy.destPath)
+		s.True(strategy.gotReader)
 		s.Equal(expectedDesc.MediaType, desc.MediaType)
 		s.Equal(expectedDesc.Digest, desc.Digest)
 		s.Equal(expectedDesc.Size, desc.Size)


### PR DESCRIPTION
## Summary

Fix a data race in `TestBuilderSuite/TestBuildLayer` reported by `go test -race ./pkg/backend/build/...`. **Test-only change; production code is untouched.**

## Root cause

`BuildLayer` hands `OutputLayer` a live `*io.PipeReader` whose backing tar-writer goroutine (`archiver.Tar`) is mid-write. The subtest uses the generated testify mock for `OutputStrategy`, and testify's `mock.Arguments.Diff` formats **every** actual argument with `fmt` (`fmt.Sprintf("(%[1]T=%[1]v)", actual)`) to match the call. Formatting the `*io.PipeReader` reflects into the pipe's internal `sync.Mutex` state concurrently with the writer goroutine's `Lock()` — the reported race.

```
Write by goroutine (tar): io.(*pipe).write -> sync.(*Mutex).Lock
Read  by goroutine (test): fmt.Sprintf -> reflect.Value.Interface  <- testify Arguments.Diff
```

No mock matcher avoids it: `Diff` formats the actual argument *before* any matcher logic runs, so `mock.Anything` / `AnythingOfType` / `MatchedBy` make no difference.

## Fix

Replace the testify mock in the "successful build layer" subtest with a small hand-written `OutputStrategy` that **reads** the reader (exactly as the real `localOutput`/`remoteOutput` strategies do). This avoids reflecting over the live pipe and unblocks the writer goroutine, while still asserting the call arguments and returned descriptor.

## Notes

- Production is unchanged. `remoteOutput.OutputLayer` relies on the reader's concrete `*io.PipeReader` type (to drain it when a blob already exists), so wrapping the reader was deliberately avoided.
- Pre-existing: this race is present on `main` today and is not currently caught by CI (the test targets don't pass `-race`).

## Test plan

- [x] `go test -race -count=20 -run TestBuilderSuite/TestBuildLayer ./pkg/backend/build/...` — clean (was failing).
- [x] `go test -race ./...` — all packages clean.
- [x] `go vet ./...` / `gofmt` clean.
